### PR TITLE
Fix tagged release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,15 @@ jobs:
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
       - run: npm ci
       - run: npm test
       - run: ${{ matrix.command }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Scrcpy-GUI-${{ matrix.artifact }}
           if-no-files-found: error
@@ -49,10 +49,10 @@ jobs:
     needs: package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,8 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git+https://github.com/SimonAKing/scrcpy-gui.git"
   },
   "bugs": "https://github.com/SimonAKing/scrcpy-gui/issues",
+  "desktopName": "scrcpy-gui.desktop",
   "license": "GPL-3.0-only",
   "private": true,
   "main": "out/main/main.js",
@@ -20,10 +21,10 @@
     "typecheck": "vue-tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.node.json",
     "build": "npm run typecheck && electron-vite build",
     "build:dir": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder",
-    "dist:mac": "npm run build && electron-builder --mac --x64 --arm64",
-    "dist:win": "npm run build && electron-builder --win --x64",
-    "dist:linux": "npm run build && electron-builder --linux --x64"
+    "dist": "npm run build && electron-builder --publish never",
+    "dist:mac": "npm run build && electron-builder --mac --x64 --arm64 --publish never",
+    "dist:win": "npm run build && electron-builder --win --x64 --publish never",
+    "dist:linux": "npm run build && electron-builder --linux --x64 --publish never"
   },
   "dependencies": {
     "vue": "^3.5.41"
@@ -82,6 +83,7 @@
     "linux": {
       "icon": "build/icons",
       "category": "Utility",
+      "syncDesktopName": true,
       "target": [
         "AppImage",
         "deb"


### PR DESCRIPTION
## Summary

- prevent electron-builder from auto-publishing during platform packaging; the publish job owns release creation
- update GitHub Actions to current Node 24-compatible major versions
- set a stable Linux desktop name and synchronize the desktop entry

## Root cause

All three platform packages were successfully built in the first tagged run, then electron-builder auto-detected the tag and attempted a second publishing path without a PAT. `--publish never` makes artifact generation deterministic and leaves publishing to `softprops/action-gh-release`.

## Verification

- `npm test`
- `npm run build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false npm run dist:mac`
- both x64 and arm64 DMG/ZIP artifacts completed locally without a publish attempt