### PR TITLE
fix: make beta release packaging portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      - name: Install Linux packaging tools
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes libarchive-tools
       - run: npm ci
       - run: npm test
       - run: ${{ matrix.command }}

--- a/scripts/fetch-scrcpy.mjs
+++ b/scripts/fetch-scrcpy.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdtemp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -57,7 +57,7 @@ for (const artifact of selected) {
 
   await writeFile(join(extracted, '.scrcpy-bundle'), `${VERSION} ${artifact.sha256}\n`)
   await rm(destination, { recursive: true, force: true })
-  await rename(extracted, destination)
+  await cp(extracted, destination, { recursive: true })
   await rm(temporary, { recursive: true, force: true })
   console.log(`Prepared verified scrcpy ${VERSION} bundle for ${artifact.arch}.`)
 }


### PR DESCRIPTION
## Root causes

- Windows downloaded the verified scrcpy archive to the runner C: drive, then attempted to rename it into the D: checkout. Node correctly rejected that cross-device rename with EXDEV. Copy the verified extracted directory instead.
- The pacman target invokes bsdtar to build its MTREE, but ubuntu-latest does not include it. Install libarchive-tools before Linux packaging.

## Verification

- `node --check scripts/fetch-scrcpy.mjs`
- `npm test` (28 tests)
- `git diff --check`

This follow-up repairs the v2.0.0-beta.2 release pipeline; it does not change application behavior.