### PR TITLE
fix: stabilize release asset names

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "appId": "com.simonaking.scrcpygui",
     "productName": "Scrcpy GUI",
     "copyright": "Copyright © 2019-2026 Simon Ma and contributors",
-    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "artifactName": "Scrcpy.GUI-${version}-${os}-${arch}.${ext}",
     "directories": {
       "output": "release"
     },


### PR DESCRIPTION
## Root cause

Electron Builder preserved the space in `productName` when naming installers, while the Chocolatey source and release workflow intentionally referenced a stable `Scrcpy.GUI-...` asset name. The application packages built successfully, but the checksum step could not find the x64 installer.

Set an explicit artifact name that matches the Chocolatey URL, verification instructions, and workflow.

## Verification

- `npm test` (28 tests)
- `git diff --check`
- The existing release job itself validates the exact installer filename before calculating its SHA-256.