### PR TITLE
docs: remove QQ group links

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Bu
 ## Community and credits
 
 - Questions, bugs, and feature requests: [GitHub Issues](https://github.com/SimonAKing/scrcpy-gui/issues)
-- Chinese community: [Scrcpy-GUI QQ group](https://jq.qq.com/?_wv=1027&k=5jxRe2o)
 - The Russian translation was originally contributed by [@dEN5-tech](https://github.com/dEN5-tech) in [#69](https://github.com/SimonAKing/scrcpy-gui/pull/69) and migrated to the 2.0 interface.
 - Thanks to [Genymobile/scrcpy](https://github.com/Genymobile/scrcpy) and every Scrcpy GUI contributor.
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -192,7 +192,6 @@ npm run build:dir
 ## 社区与致谢
 
 - 问题、Bug 与功能建议：[GitHub Issues](https://github.com/SimonAKing/scrcpy-gui/issues)
-- 中文社区：[Scrcpy-GUI QQ 群](https://jq.qq.com/?_wv=1027&k=5jxRe2o)
 - 俄语翻译最初由 [@dEN5-tech](https://github.com/dEN5-tech) 在 [#69](https://github.com/SimonAKing/scrcpy-gui/pull/69) 中贡献，并已迁移到 2.0 界面。
 - 感谢 [Genymobile/scrcpy](https://github.com/Genymobile/scrcpy) 以及 Scrcpy GUI 的所有贡献者。
 


### PR DESCRIPTION
Remove the obsolete QQ group entry from both the English and Simplified Chinese READMEs.

Verification: repository-wide search confirms no QQ group copy or invite URL remains.