### PR TITLE
security: harden Electron privilege boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- Validate every privileged IPC call against the main application frame and trusted renderer URL.
+- Deny renderer permission requests, new windows, and navigation to untrusted locations.
+- Apply a production-only Content Security Policy that removes development localhost access and blocks object, base, and form targets.
+
 ## 2.0.0-beta.3
 
 ### Changed

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,6 @@
-import { app, BrowserWindow, dialog, globalShortcut, ipcMain, Menu, nativeImage, shell, Tray } from 'electron'
+import { app, BrowserWindow, dialog, globalShortcut, ipcMain, Menu, nativeImage, session, shell, Tray } from 'electron'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import type {
   AutomationStep,
   DeviceControlAction,
@@ -22,6 +23,7 @@ import {
   stopAllScrcpy,
   stopScrcpy
 } from './processes'
+import { isTrustedRendererUrl, PRODUCTION_CSP } from './security'
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
@@ -31,6 +33,42 @@ let registeredBossKey = ''
 let killAdbOnQuit = false
 let quitRuntime: RuntimeConfig = { scrcpyPath: '' }
 let shutdownStarted = false
+const rendererEntryUrl = pathToFileURL(join(__dirname, '../renderer/index.html')).toString()
+
+function rendererUrlIsTrusted(url: string): boolean {
+  return isTrustedRendererUrl(url, rendererEntryUrl, process.env.ELECTRON_RENDERER_URL)
+}
+
+function assertTrustedIpcSender(event: Electron.IpcMainInvokeEvent): void {
+  if (
+    !mainWindow ||
+    event.sender !== mainWindow.webContents ||
+    event.senderFrame !== mainWindow.webContents.mainFrame ||
+    !rendererUrlIsTrusted(event.senderFrame.url)
+  ) {
+    throw new Error('Rejected IPC request from an untrusted renderer.')
+  }
+}
+
+const handle: typeof ipcMain.handle = (channel, listener) => {
+  ipcMain.handle(channel, (event, ...args) => {
+    assertTrustedIpcSender(event)
+    return listener(event, ...args)
+  })
+}
+
+function configureSessionSecurity(): void {
+  session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
+  if (!app.isPackaged) return
+  session.defaultSession.webRequest.onHeadersReceived({ urls: ['file://*/*'] }, (details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [PRODUCTION_CSP]
+      }
+    })
+  })
+}
 
 function sendStatus(status: ScrcpyStatusEvent): void {
   if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('scrcpy:status', status)
@@ -54,6 +92,10 @@ function createWindow(): void {
   })
 
   mainWindow.setMenuBarVisibility(false)
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!rendererUrlIsTrusted(url)) event.preventDefault()
+  })
+  mainWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
   mainWindow.once('ready-to-show', () => mainWindow?.show())
   mainWindow.on('close', (event) => {
     if (minimizeToTray && !isQuitting) {
@@ -116,18 +158,18 @@ function setBossKey(enabled: boolean, accelerator: string): OperationResult<stri
   }
 }
 
-ipcMain.handle('app:version', () => app.getVersion())
-ipcMain.handle('app:minimize-to-tray', (_event, enabled: boolean) => {
+handle('app:version', () => app.getVersion())
+handle('app:minimize-to-tray', (_event, enabled: boolean) => {
   minimizeToTray = Boolean(enabled)
 })
-ipcMain.handle('app:quit-behavior', (_event, runtime: RuntimeConfig, shouldKillAdb: boolean) => {
+handle('app:quit-behavior', (_event, runtime: RuntimeConfig, shouldKillAdb: boolean) => {
   quitRuntime = { scrcpyPath: String(runtime?.scrcpyPath || '') }
   killAdbOnQuit = Boolean(shouldKillAdb)
 })
-ipcMain.handle('app:boss-key', (_event, enabled: boolean, accelerator: string) =>
+handle('app:boss-key', (_event, enabled: boolean, accelerator: string) =>
   setBossKey(Boolean(enabled), String(accelerator || ''))
 )
-ipcMain.handle('dialog:scrcpy', async () => {
+handle('dialog:scrcpy', async () => {
   const result = await dialog.showOpenDialog({
     title: 'Choose the scrcpy executable',
     properties: ['openFile'],
@@ -135,7 +177,7 @@ ipcMain.handle('dialog:scrcpy', async () => {
   })
   return result.canceled ? '' : result.filePaths[0] || ''
 })
-ipcMain.handle('dialog:record', async () => {
+handle('dialog:record', async () => {
   const result = await dialog.showSaveDialog({
     title: 'Choose recording destination',
     defaultPath: `scrcpy-${new Date().toISOString().replaceAll(':', '-').slice(0, 19)}.mp4`,
@@ -146,7 +188,7 @@ ipcMain.handle('dialog:record', async () => {
   })
   return result.canceled ? '' : result.filePath || ''
 })
-ipcMain.handle('dialog:record-directory', async () => {
+handle('dialog:record-directory', async () => {
   const result = await dialog.showOpenDialog({
     title: 'Choose recording folder',
     defaultPath: app.getPath('videos'),
@@ -154,27 +196,27 @@ ipcMain.handle('dialog:record-directory', async () => {
   })
   return result.canceled ? '' : result.filePaths[0] || ''
 })
-ipcMain.handle('system:environment', (_event, runtime: RuntimeConfig) => getEnvironment(runtime))
-ipcMain.handle('device:list', (_event, runtime: RuntimeConfig) => listDevices(runtime))
-ipcMain.handle('device:connect', (_event, runtime: RuntimeConfig, target: string) => connectDevice(runtime, target))
-ipcMain.handle('device:pair', (_event, runtime: RuntimeConfig, target: string, code: string) =>
+handle('system:environment', (_event, runtime: RuntimeConfig) => getEnvironment(runtime))
+handle('device:list', (_event, runtime: RuntimeConfig) => listDevices(runtime))
+handle('device:connect', (_event, runtime: RuntimeConfig, target: string) => connectDevice(runtime, target))
+handle('device:pair', (_event, runtime: RuntimeConfig, target: string, code: string) =>
   pairDevice(runtime, target, code)
 )
-ipcMain.handle('device:disconnect', (_event, runtime: RuntimeConfig, target: string) =>
+handle('device:disconnect', (_event, runtime: RuntimeConfig, target: string) =>
   disconnectDevice(runtime, target)
 )
-ipcMain.handle(
+handle(
   'scrcpy:start',
   (_event, runtime: RuntimeConfig, launches: DeviceLaunch[]) =>
     startScrcpy(runtime, launches, sendStatus)
 )
-ipcMain.handle('scrcpy:stop', (_event, serial: string) => stopScrcpy(serial))
-ipcMain.handle(
+handle('scrcpy:stop', (_event, serial: string) => stopScrcpy(serial))
+handle(
   'device:control',
   (_event, runtime: RuntimeConfig, serial: string, action: DeviceControlAction) =>
     controlDevice(runtime, serial, action)
 )
-ipcMain.handle('device:screenshot', async (_event, runtime: RuntimeConfig, serial: string) => {
+handle('device:screenshot', async (_event, runtime: RuntimeConfig, serial: string) => {
   const safeSerial = serial.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 80) || 'device'
   const timestamp = new Date().toISOString().replaceAll(':', '-').slice(0, 19)
   const result = await dialog.showSaveDialog({
@@ -185,12 +227,12 @@ ipcMain.handle('device:screenshot', async (_event, runtime: RuntimeConfig, seria
   if (result.canceled || !result.filePath) return { ok: false, error: 'Screenshot canceled.' }
   return captureDeviceScreenshot(runtime, serial, result.filePath)
 })
-ipcMain.handle(
+handle(
   'device:automation',
   (_event, runtime: RuntimeConfig, serial: string, steps: AutomationStep[]) =>
     runDeviceAutomation(runtime, serial, steps)
 )
-ipcMain.handle('shell:open', async (_event, rawUrl: string) => {
+handle('shell:open', async (_event, rawUrl: string) => {
   const url = new URL(rawUrl)
   const allowedHosts = new Set(['github.com', 'scrcpyapp.org'])
   if (url.protocol !== 'https:' || !allowedHosts.has(url.hostname)) throw new Error('External URL is not allowed.')
@@ -198,6 +240,7 @@ ipcMain.handle('shell:open', async (_event, rawUrl: string) => {
 })
 
 app.whenReady().then(() => {
+  configureSessionSecurity()
   createWindow()
   createTray()
   app.on('activate', () => {

--- a/src/main/security.ts
+++ b/src/main/security.ts
@@ -1,0 +1,32 @@
+export const PRODUCTION_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'"
+].join('; ')
+
+export function isTrustedRendererUrl(candidate: string, packagedEntry: string, devRendererUrl?: string): boolean {
+  try {
+    const actual = new URL(candidate)
+    if (devRendererUrl) {
+      const expected = new URL(devRendererUrl)
+      return (
+        (expected.protocol === 'http:' || expected.protocol === 'https:') &&
+        actual.protocol === expected.protocol &&
+        actual.origin === expected.origin
+      )
+    }
+
+    const expected = new URL(packagedEntry)
+    actual.hash = ''
+    expected.hash = ''
+    return actual.protocol === 'file:' && actual.href === expected.href
+  } catch {
+    return false
+  }
+}

--- a/tests/scrcpy.test.ts
+++ b/tests/scrcpy.test.ts
@@ -8,6 +8,7 @@ import {
   validateDeviceAddress,
   validatePortRange
 } from '../src/main/scrcpy'
+import { isTrustedRendererUrl, PRODUCTION_CSP } from '../src/main/security'
 
 function config(overrides: Partial<LaunchConfig> = {}): LaunchConfig {
   return {
@@ -171,5 +172,31 @@ describe('splitExtraArgs', () => {
 
   it('prevents callers from overriding the selected device', () => {
     expect(() => splitExtraArgs('--serial=other-device')).toThrow('cannot be overridden')
+  })
+})
+
+describe('renderer security boundary', () => {
+  const packagedEntry = 'file:///Applications/Scrcpy%20GUI.app/Contents/Resources/app.asar/out/renderer/index.html'
+
+  it('accepts only the packaged renderer entry and its hash routes', () => {
+    expect(isTrustedRendererUrl(packagedEntry, packagedEntry)).toBe(true)
+    expect(isTrustedRendererUrl(`${packagedEntry}#devices`, packagedEntry)).toBe(true)
+    expect(isTrustedRendererUrl(`${packagedEntry}?redirect=https://example.com`, packagedEntry)).toBe(false)
+    expect(isTrustedRendererUrl('file:///tmp/index.html', packagedEntry)).toBe(false)
+    expect(isTrustedRendererUrl('https://example.com', packagedEntry)).toBe(false)
+  })
+
+  it('accepts only the configured development origin', () => {
+    const devUrl = 'http://localhost:5173/'
+    expect(isTrustedRendererUrl('http://localhost:5173/settings', packagedEntry, devUrl)).toBe(true)
+    expect(isTrustedRendererUrl('http://localhost:5174/', packagedEntry, devUrl)).toBe(false)
+    expect(isTrustedRendererUrl('https://localhost:5173/', packagedEntry, devUrl)).toBe(false)
+    expect(isTrustedRendererUrl('not a url', packagedEntry, devUrl)).toBe(false)
+  })
+
+  it('uses a production CSP without localhost network access', () => {
+    expect(PRODUCTION_CSP).toContain("connect-src 'self'")
+    expect(PRODUCTION_CSP).toContain("object-src 'none'")
+    expect(PRODUCTION_CSP).not.toContain('localhost')
   })
 })


### PR DESCRIPTION
## Evidence

Every privileged IPC handler previously accepted requests without validating the calling frame. The BrowserWindow also had no common navigation/window-open denial or session permission policy. Electron official guidance recommends validating IPC senders, limiting navigation/new windows, denying unneeded permissions, and applying a restrictive CSP.

## Changes

- Route all privileged handlers through a trusted main-frame check
- Accept only the packaged renderer entry, or the configured dev-server origin during development
- Deny permission requests, new windows, and navigation to untrusted URLs
- Apply a packaged-app CSP response header without localhost access; block object/base/form targets
- Add pure URL-boundary and production-CSP tests
- Record the security changes under Unreleased

## Verification

- `npm run typecheck`
- `npm test` (31 tests)
- `npm run build`
- `git diff --check`
- Direct app run: trusted IPC returns app version and environment
- Packaged app run: bundled scrcpy 4.1 and adb are both ready
- CDP-observed packaged Document CSP exactly matches the restrictive production policy

The application behavior and release version are unchanged; this is the first M0 hardening slice from the product technical specification.