### PR TITLE
security: validate privileged IPC payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security
 
 - Validate every privileged IPC call against the main application frame and trusted renderer URL.
+- Validate and normalize privileged IPC payloads at runtime, with bounded paths, device batches, expert arguments, and automations.
 - Deny renderer permission requests, new windows, and navigation to untrusted locations.
 - Apply a production-only Content Security Policy that removes development localhost access and blocks object, base, and form targets.
 

--- a/src/main/ipcValidation.ts
+++ b/src/main/ipcValidation.ts
@@ -1,0 +1,158 @@
+import type {
+  AutomationStep,
+  DeviceControlAction,
+  DeviceLaunch,
+  GamepadMode,
+  KeyboardMode,
+  LaunchConfig,
+  MouseMode,
+  Orientation,
+  RuntimeConfig,
+  ShortcutModifier,
+  VideoCodec
+} from '../shared/types'
+
+const MAX_PATH_LENGTH = 4096
+const MAX_SERIAL_LENGTH = 512
+const MAX_EXTRA_ARGS_LENGTH = 65_536
+const MAX_EXTRA_ARGS = 200
+const MAX_AUTOMATION_STEPS = 200
+const MAX_AUTOMATION_DURATION_MS = 30 * 60 * 1000
+
+const orientations = new Set<Orientation>(['0', '90', '180', '270'])
+const shortcutModifiers = new Set<ShortcutModifier>(['default', 'lctrl', 'rctrl', 'lalt', 'ralt', 'lsuper', 'rsuper'])
+const keyboardModes = new Set<KeyboardMode>(['default', 'sdk', 'uhid', 'aoa'])
+const mouseModes = new Set<MouseMode>(['default', 'sdk', 'uhid', 'aoa', 'disabled'])
+const gamepadModes = new Set<GamepadMode>(['default', 'uhid', 'aoa'])
+const videoCodecs = new Set<VideoCodec>(['default', 'h264', 'h265', 'av1', 'vp8', 'vp9'])
+const controlActions = new Set<DeviceControlAction>([
+  'back', 'home', 'app-switch', 'menu', 'volume-up', 'volume-down', 'power', 'screen-on', 'screen-off',
+  'rotate', 'auto-rotate', 'show-touches-on', 'show-touches-off'
+])
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError(`${name} must be an object.`)
+  return value as Record<string, unknown>
+}
+
+export function boundedString(value: unknown, name: string, maxLength: number, allowEmpty = false): string {
+  if (typeof value !== 'string') throw new TypeError(`${name} must be a string.`)
+  if (value.includes('\0')) throw new TypeError(`${name} may not contain null bytes.`)
+  if ((!allowEmpty && value.length === 0) || value.length > maxLength) {
+    throw new TypeError(`${name} must contain ${allowEmpty ? '0' : '1'} to ${maxLength} characters.`)
+  }
+  return value
+}
+
+export function strictBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== 'boolean') throw new TypeError(`${name} must be a boolean.`)
+  return value
+}
+
+function finiteNumber(value: unknown, name: string, min: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max) {
+    throw new TypeError(`${name} must be a finite number from ${min} to ${max}.`)
+  }
+  return value
+}
+
+function enumValue<T extends string>(value: unknown, name: string, values: Set<T>): T {
+  if (typeof value !== 'string' || !values.has(value as T)) throw new TypeError(`${name} is not supported.`)
+  return value as T
+}
+
+function booleanField(source: Record<string, unknown>, key: keyof LaunchConfig): boolean {
+  return strictBoolean(source[key], `launch.${key}`)
+}
+
+function geometry(value: unknown, name: 'crop' | 'window'): LaunchConfig[typeof name] {
+  const source = record(value, `launch.${name}`)
+  return {
+    x: finiteNumber(source.x, `launch.${name}.x`, -32_768, 32_768),
+    y: finiteNumber(source.y, `launch.${name}.y`, -32_768, 32_768),
+    width: finiteNumber(source.width, `launch.${name}.width`, 0, 32_768),
+    height: finiteNumber(source.height, `launch.${name}.height`, 0, 32_768)
+  }
+}
+
+export function runtimeConfig(value: unknown): RuntimeConfig {
+  const source = record(value, 'runtime')
+  return { scrcpyPath: boundedString(source.scrcpyPath, 'runtime.scrcpyPath', MAX_PATH_LENGTH, true) }
+}
+
+export function deviceSerial(value: unknown): string {
+  return boundedString(value, 'device serial', MAX_SERIAL_LENGTH)
+}
+
+export function controlAction(value: unknown): DeviceControlAction {
+  return enumValue(value, 'device control action', controlActions)
+}
+
+export function launchConfig(value: unknown): LaunchConfig {
+  const source = record(value, 'launch')
+  const extraArgs = boundedString(source.extraArgs, 'launch.extraArgs', MAX_EXTRA_ARGS_LENGTH, true)
+  const lines = extraArgs.split(/\r?\n/).filter((line) => line.trim())
+  if (lines.length > MAX_EXTRA_ARGS || lines.some((line) => line.length > 4096)) {
+    throw new TypeError(`launch.extraArgs supports at most ${MAX_EXTRA_ARGS} lines of 4096 characters.`)
+  }
+
+  return {
+    windowTitle: boundedString(source.windowTitle, 'launch.windowTitle', 256, true),
+    videoBitRate: finiteNumber(source.videoBitRate, 'launch.videoBitRate', 0, 1000),
+    videoBuffer: finiteNumber(source.videoBuffer, 'launch.videoBuffer', 0, 60_000),
+    audioBuffer: finiteNumber(source.audioBuffer, 'launch.audioBuffer', 0, 60_000),
+    maxSize: finiteNumber(source.maxSize, 'launch.maxSize', 0, 32_768),
+    maxFps: finiteNumber(source.maxFps, 'launch.maxFps', 0, 1000),
+    displayId: finiteNumber(source.displayId, 'launch.displayId', 0, 65_535),
+    orientation: enumValue(source.orientation, 'launch.orientation', orientations),
+    videoCodec: enumValue(source.videoCodec, 'launch.videoCodec', videoCodecs),
+    shortcutModifier: enumValue(source.shortcutModifier, 'launch.shortcutModifier', shortcutModifiers),
+    keyboardMode: enumValue(source.keyboardMode, 'launch.keyboardMode', keyboardModes),
+    mouseMode: enumValue(source.mouseMode, 'launch.mouseMode', mouseModes),
+    gamepadMode: enumValue(source.gamepadMode, 'launch.gamepadMode', gamepadModes),
+    alwaysOnTop: booleanField(source, 'alwaysOnTop'),
+    control: booleanField(source, 'control'),
+    audio: booleanField(source, 'audio'),
+    turnScreenOff: booleanField(source, 'turnScreenOff'),
+    stayAwake: booleanField(source, 'stayAwake'),
+    showTouches: booleanField(source, 'showTouches'),
+    fullscreen: booleanField(source, 'fullscreen'),
+    borderless: booleanField(source, 'borderless'),
+    windowAspectRatioLock: booleanField(source, 'windowAspectRatioLock'),
+    pushTarget: boundedString(source.pushTarget, 'launch.pushTarget', MAX_PATH_LENGTH, true),
+    tunnelPort: boundedString(source.tunnelPort, 'launch.tunnelPort', 11, true),
+    recordEnabled: booleanField(source, 'recordEnabled'),
+    recordPath: boundedString(source.recordPath, 'launch.recordPath', MAX_PATH_LENGTH, true),
+    autoRecordName: booleanField(source, 'autoRecordName'),
+    recordDirectory: boundedString(source.recordDirectory, 'launch.recordDirectory', MAX_PATH_LENGTH, true),
+    noPlayback: booleanField(source, 'noPlayback'),
+    crop: geometry(source.crop, 'crop'),
+    window: geometry(source.window, 'window'),
+    extraArgs
+  }
+}
+
+export function deviceLaunches(value: unknown): DeviceLaunch[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 100) {
+    throw new TypeError('launches must contain 1 to 100 devices.')
+  }
+  return value.map((item, index) => {
+    const source = record(item, `launches[${index}]`)
+    return { serial: deviceSerial(source.serial), launch: launchConfig(source.launch) }
+  })
+}
+
+export function automationSteps(value: unknown): AutomationStep[] {
+  if (!Array.isArray(value) || value.length > MAX_AUTOMATION_STEPS) {
+    throw new TypeError(`automation steps must contain 0 to ${MAX_AUTOMATION_STEPS} actions.`)
+  }
+  let totalDuration = 0
+  const steps = value.map((item, index) => {
+    const source = record(item, `steps[${index}]`)
+    const delayMs = finiteNumber(source.delayMs, `steps[${index}].delayMs`, 0, 60_000)
+    totalDuration += delayMs
+    return { action: controlAction(source.action), delayMs }
+  })
+  if (totalDuration > MAX_AUTOMATION_DURATION_MS) throw new TypeError('automation duration may not exceed 30 minutes.')
+  return steps
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,6 +23,15 @@ import {
   stopAllScrcpy,
   stopScrcpy
 } from './processes'
+import {
+  automationSteps,
+  boundedString,
+  controlAction,
+  deviceLaunches,
+  deviceSerial,
+  runtimeConfig,
+  strictBoolean
+} from './ipcValidation'
 import { isTrustedRendererUrl, PRODUCTION_CSP } from './security'
 
 let mainWindow: BrowserWindow | null = null
@@ -160,14 +169,14 @@ function setBossKey(enabled: boolean, accelerator: string): OperationResult<stri
 
 handle('app:version', () => app.getVersion())
 handle('app:minimize-to-tray', (_event, enabled: boolean) => {
-  minimizeToTray = Boolean(enabled)
+  minimizeToTray = strictBoolean(enabled, 'minimizeToTray')
 })
 handle('app:quit-behavior', (_event, runtime: RuntimeConfig, shouldKillAdb: boolean) => {
-  quitRuntime = { scrcpyPath: String(runtime?.scrcpyPath || '') }
-  killAdbOnQuit = Boolean(shouldKillAdb)
+  quitRuntime = runtimeConfig(runtime)
+  killAdbOnQuit = strictBoolean(shouldKillAdb, 'killAdbOnQuit')
 })
 handle('app:boss-key', (_event, enabled: boolean, accelerator: string) =>
-  setBossKey(Boolean(enabled), String(accelerator || ''))
+  setBossKey(strictBoolean(enabled, 'bossKeyEnabled'), boundedString(accelerator, 'bossKeyAccelerator', 128, true))
 )
 handle('dialog:scrcpy', async () => {
   const result = await dialog.showOpenDialog({
@@ -196,28 +205,36 @@ handle('dialog:record-directory', async () => {
   })
   return result.canceled ? '' : result.filePaths[0] || ''
 })
-handle('system:environment', (_event, runtime: RuntimeConfig) => getEnvironment(runtime))
-handle('device:list', (_event, runtime: RuntimeConfig) => listDevices(runtime))
-handle('device:connect', (_event, runtime: RuntimeConfig, target: string) => connectDevice(runtime, target))
+handle('system:environment', (_event, runtime: RuntimeConfig) => getEnvironment(runtimeConfig(runtime)))
+handle('device:list', (_event, runtime: RuntimeConfig) => listDevices(runtimeConfig(runtime)))
+handle('device:connect', (_event, runtime: RuntimeConfig, target: string) =>
+  connectDevice(runtimeConfig(runtime), boundedString(target, 'wireless target', 512))
+)
 handle('device:pair', (_event, runtime: RuntimeConfig, target: string, code: string) =>
-  pairDevice(runtime, target, code)
+  pairDevice(
+    runtimeConfig(runtime),
+    boundedString(target, 'pairing target', 512),
+    boundedString(code, 'pairing code', 6)
+  )
 )
 handle('device:disconnect', (_event, runtime: RuntimeConfig, target: string) =>
-  disconnectDevice(runtime, target)
+  disconnectDevice(runtimeConfig(runtime), boundedString(target, 'wireless target', 512))
 )
 handle(
   'scrcpy:start',
   (_event, runtime: RuntimeConfig, launches: DeviceLaunch[]) =>
-    startScrcpy(runtime, launches, sendStatus)
+    startScrcpy(runtimeConfig(runtime), deviceLaunches(launches), sendStatus)
 )
-handle('scrcpy:stop', (_event, serial: string) => stopScrcpy(serial))
+handle('scrcpy:stop', (_event, serial: string) => stopScrcpy(deviceSerial(serial)))
 handle(
   'device:control',
   (_event, runtime: RuntimeConfig, serial: string, action: DeviceControlAction) =>
-    controlDevice(runtime, serial, action)
+    controlDevice(runtimeConfig(runtime), deviceSerial(serial), controlAction(action))
 )
 handle('device:screenshot', async (_event, runtime: RuntimeConfig, serial: string) => {
-  const safeSerial = serial.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 80) || 'device'
+  const validatedRuntime = runtimeConfig(runtime)
+  const validatedSerial = deviceSerial(serial)
+  const safeSerial = validatedSerial.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 80) || 'device'
   const timestamp = new Date().toISOString().replaceAll(':', '-').slice(0, 19)
   const result = await dialog.showSaveDialog({
     title: 'Save device screenshot',
@@ -225,15 +242,15 @@ handle('device:screenshot', async (_event, runtime: RuntimeConfig, serial: strin
     filters: [{ name: 'PNG image', extensions: ['png'] }]
   })
   if (result.canceled || !result.filePath) return { ok: false, error: 'Screenshot canceled.' }
-  return captureDeviceScreenshot(runtime, serial, result.filePath)
+  return captureDeviceScreenshot(validatedRuntime, validatedSerial, result.filePath)
 })
 handle(
   'device:automation',
   (_event, runtime: RuntimeConfig, serial: string, steps: AutomationStep[]) =>
-    runDeviceAutomation(runtime, serial, steps)
+    runDeviceAutomation(runtimeConfig(runtime), deviceSerial(serial), automationSteps(steps))
 )
 handle('shell:open', async (_event, rawUrl: string) => {
-  const url = new URL(rawUrl)
+  const url = new URL(boundedString(rawUrl, 'external URL', 2048))
   const allowedHosts = new Set(['github.com', 'scrcpyapp.org'])
   if (url.protocol !== 'https:' || !allowedHosts.has(url.hostname)) throw new Error('External URL is not allowed.')
   await shell.openExternal(url.toString())

--- a/tests/ipcValidation.test.ts
+++ b/tests/ipcValidation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { LaunchConfig } from '../src/shared/types'
+import {
+  automationSteps,
+  boundedString,
+  controlAction,
+  deviceLaunches,
+  deviceSerial,
+  launchConfig,
+  runtimeConfig,
+  strictBoolean
+} from '../src/main/ipcValidation'
+
+function validLaunch(overrides: Partial<LaunchConfig> = {}): LaunchConfig {
+  return {
+    windowTitle: '', videoBitRate: 8, videoBuffer: 0, audioBuffer: 0, maxSize: 0, maxFps: 0, displayId: 0,
+    orientation: '0', videoCodec: 'default', shortcutModifier: 'default', keyboardMode: 'default',
+    mouseMode: 'default', gamepadMode: 'default', alwaysOnTop: false, control: true, audio: true,
+    turnScreenOff: false, stayAwake: false, showTouches: false, fullscreen: false, borderless: false,
+    windowAspectRatioLock: true, pushTarget: '', tunnelPort: '', recordEnabled: false, recordPath: '',
+    autoRecordName: false, recordDirectory: '', noPlayback: false,
+    crop: { x: 0, y: 0, width: 0, height: 0 }, window: { x: 0, y: 0, width: 0, height: 0 }, extraArgs: '',
+    ...overrides
+  }
+}
+
+describe('IPC scalar validation', () => {
+  it('accepts bounded strings and exact booleans', () => {
+    expect(boundedString('device', 'name', 20)).toBe('device')
+    expect(strictBoolean(false, 'enabled')).toBe(false)
+    expect(deviceSerial('ABC123')).toBe('ABC123')
+    expect(controlAction('home')).toBe('home')
+  })
+
+  it('rejects coercion, null bytes and oversized values', () => {
+    expect(() => strictBoolean(1, 'enabled')).toThrow('must be a boolean')
+    expect(() => boundedString('bad\0value', 'name', 20)).toThrow('null bytes')
+    expect(() => deviceSerial('')).toThrow('1 to 512')
+    expect(() => deviceSerial('x'.repeat(513))).toThrow('1 to 512')
+    expect(() => controlAction('shell')).toThrow('not supported')
+  })
+})
+
+describe('IPC runtime and launch validation', () => {
+  it('normalizes valid runtime and launch requests', () => {
+    expect(runtimeConfig({ scrcpyPath: '' })).toEqual({ scrcpyPath: '' })
+    expect(launchConfig(validLaunch({ videoCodec: 'vp9', maxFps: 120 }))).toMatchObject({
+      videoCodec: 'vp9', maxFps: 120
+    })
+    expect(deviceLaunches([{ serial: 'ABC123', launch: validLaunch() }])).toHaveLength(1)
+  })
+
+  it('rejects malformed launch values before process construction', () => {
+    expect(() => runtimeConfig({ scrcpyPath: 12 })).toThrow('must be a string')
+    expect(() => launchConfig({ ...validLaunch(), maxFps: Number.NaN })).toThrow('finite number')
+    expect(() => launchConfig({ ...validLaunch(), videoCodec: 'mpeg2' })).toThrow('not supported')
+    expect(() => launchConfig({ ...validLaunch(), audio: 'yes' })).toThrow('must be a boolean')
+    expect(() => launchConfig({ ...validLaunch(), extraArgs: `${'x'.repeat(4097)}\n` })).toThrow('at most 200 lines')
+  })
+
+  it('limits batch launch size', () => {
+    expect(() => deviceLaunches([])).toThrow('1 to 100')
+    expect(() => deviceLaunches(Array.from({ length: 101 }, (_, index) => ({
+      serial: `device-${index}`, launch: validLaunch()
+    })))).toThrow('1 to 100')
+  })
+})
+
+describe('IPC automation validation', () => {
+  it('accepts safe actions and delays', () => {
+    expect(automationSteps([{ action: 'back', delayMs: 250 }])).toEqual([{ action: 'back', delayMs: 250 }])
+  })
+
+  it('rejects unsafe, oversized and overlong automations', () => {
+    expect(() => automationSteps([{ action: 'shell', delayMs: 0 }])).toThrow('not supported')
+    expect(() => automationSteps([{ action: 'home', delayMs: 60_001 }])).toThrow('0 to 60000')
+    expect(() => automationSteps(Array.from({ length: 31 }, () => ({ action: 'home', delayMs: 60_000 })))).toThrow(
+      '30 minutes'
+    )
+    expect(() => automationSteps(Array.from({ length: 201 }, () => ({ action: 'home', delayMs: 0 })))).toThrow(
+      '0 to 200'
+    )
+  })
+})


### PR DESCRIPTION
## Evidence

The Electron boundary now verifies the calling frame, but handler payloads still relied on compile-time TypeScript types. A compromised or malformed renderer can send arbitrary runtime values, including huge arrays, non-finite numbers, unsupported actions, or oversized strings.

## Changes

- Add dependency-free runtime validators for strings, booleans, runtime config, serials, control actions, launch config, batches, and automations
- Normalize every privileged handler input before it reaches process, ADB, dialog, shortcut, or shell services
- Limit batches to 100 devices
- Limit expert args to 200 lines / 64 KiB and reject null bytes
- Limit automation to 200 steps, 60 seconds per delay, and 30 minutes total
- Validate every launch enum, boolean, numeric bound, geometry, and path length
- Add a dedicated validation test suite

## Verification

- `npm run typecheck`
- `npm test` (38 tests across 2 files)
- `npm run build`
- `git diff --check`
- Real Electron IPC smoke test: normal version/environment calls succeed; a string passed to the boolean minimize API is rejected at the main-process boundary

This is the second M0 security slice from the product technical specification.