### PR TITLE
release: v2.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.0.0-beta.4
+
+This release establishes a secure, observable session foundation and replaces the remaining legacy application artwork.
+
 ### Added
 
 - Preview the exact validated argv generated for each selected device before launch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-gui",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vue": "^3.5.41"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "A modern, secure desktop GUI for scrcpy",
   "author": "Simon Ma <simon@tomotoes.com>",
   "homepage": "https://github.com/SimonAKing/scrcpy-gui",

--- a/packaging/chocolatey/scrcpy-gui.nuspec
+++ b/packaging/chocolatey/scrcpy-gui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scrcpy-gui</id>
-    <version>2.0.0-beta.3</version>
+    <version>2.0.0-beta.4</version>
     <title>Scrcpy GUI</title>
     <authors>Simon Ma and contributors</authors>
     <owners>SimonAKing</owners>


### PR DESCRIPTION
## Release contents

- trusted Electron sender, navigation, permission, and CSP boundaries
- runtime validation and limits for every privileged IPC payload
- exact per-device scrcpy argv preview
- independent managed sessions with an 8-second startup state machine and Sessions page
- controlled child-process integration tests for launch, failure, conflicts, exit, and stop
- clean generated Windows/macOS/Linux/tray icons resolving #119

## Verification

- `npm run typecheck`
- `npm test` (45 tests)
- `npm run icons:check` (11 assets)
- all feature PRs passed macOS, Linux, and Windows CI
- actual Electron IPC, bundled scrcpy 4.1 failure-state, responsive layout, CSP, and packaged-runtime smoke tests completed

After merge, tag `v2.0.0-beta.4` will trigger signed-format release packaging with signing disabled in CI, and the issue will close only after assets are published and linked.
