### PR TITLE
release: v2.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.0.0-beta.5
+
+This release completes the capability, configuration, device-tracking, command, and diagnostics foundations planned for M1.
+
 ### Added
 
 - Detect supported scrcpy scenes and probe commands from the selected runtime's real `--help` output instead of assuming every build has the same capabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-gui",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vue": "^3.5.41"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "A modern, secure desktop GUI for scrcpy",
   "author": "Simon Ma <simon@tomotoes.com>",
   "homepage": "https://github.com/SimonAKing/scrcpy-gui",

--- a/packaging/chocolatey/scrcpy-gui.nuspec
+++ b/packaging/chocolatey/scrcpy-gui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scrcpy-gui</id>
-    <version>2.0.0-beta.4</version>
+    <version>2.0.0-beta.5</version>
     <title>Scrcpy GUI</title>
     <authors>Simon Ma and contributors</authors>
     <owners>SimonAKing</owners>


### PR DESCRIPTION
## Summary
- bump application and Chocolatey metadata to 2.0.0-beta.5
- publish the completed M1 foundation: capability registry, Config V3, DeviceTracker, OptionDescriptor provenance, and structured events/errors
- move the accumulated release notes out of Unreleased

## Validation
- `npm run build`
- package, lockfile, and Chocolatey versions are aligned