### PR TITLE
chore: prepare v2.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.0.0-beta.6
+
+This release completes the device workspace, local artifact, diagnostic export, and portable profile workflows planned for M2.
+
 ### Added
 
 - Add a device workspace with read-only device details, cached launchable app discovery/start, and reviewed multi-device file push and APK installation with bounded concurrency and per-target progress/results.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-gui",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.6",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vue": "^3.5.41"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A modern, secure desktop GUI for scrcpy",
   "author": "Simon Ma <simon@tomotoes.com>",
   "homepage": "https://github.com/SimonAKing/scrcpy-gui",

--- a/packaging/chocolatey/scrcpy-gui.nuspec
+++ b/packaging/chocolatey/scrcpy-gui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scrcpy-gui</id>
-    <version>2.0.0-beta.5</version>
+    <version>2.0.0-beta.6</version>
     <title>Scrcpy GUI</title>
     <authors>Simon Ma and contributors</authors>
     <owners>SimonAKing</owners>


### PR DESCRIPTION
## Summary
- bump application, lockfile, and Chocolatey metadata to v2.0.0-beta.6
- publish the complete M2 changelog for device workspace, artifacts, diagnostics, and profile transfer

## Validation
- version parity check passed
- `npm test` — 139 tests passed
- `npm run build` — passed