### PR TITLE
feat: probe device media capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Model Camera, Virtual display, Record-only, Control-only, and OTG as validated launch scenes with official scrcpy 4.1 argv serialization, explicit conflicts, and portable Profile support.
+- Probe and cache each device's video/audio encoders, displays, cameras, declared sizes, high-speed frame rates, facing, and zoom range with bounded partial-failure reporting.
 
 ## 2.0.0-beta.6
 

--- a/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
+++ b/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
@@ -10,7 +10,7 @@
 >
 > 维护者：Simon Ma 与 Scrcpy GUI contributors
 
-> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵和 Profile 往返已落地，设备级探测、场景向导与硬件烟测仍在实施。M0 的三平台真实设备矩阵、Chocolatey 社区审核和 Stable 验收仍待外部条件完成；M4 尚未开始。
+> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返和设备级编码器/显示/相机探测已落地，场景向导、V4L2 文件预检与硬件烟测仍在实施。M0 的三平台真实设备矩阵、Chocolatey 社区审核和 Stable 验收仍待外部条件完成；M4 尚未开始。
 
 ## 0. 文档目的
 

--- a/src/main/deviceCapabilityService.ts
+++ b/src/main/deviceCapabilityService.ts
@@ -1,0 +1,167 @@
+import type {
+  CameraInfo,
+  CameraSizeInfo,
+  DeviceCapabilitySnapshot,
+  DisplayInfo,
+  EncoderInfo,
+  RuntimeConfig
+} from '../shared/types'
+import { executeCommand, resolveBinary, type CommandOutput } from './runtime'
+
+const CACHE_TTL_MS = 5 * 60_000
+const MAX_CACHE_ENTRIES = 50
+const PROBE_TIMEOUT_MS = 20_000
+const PROBE_MAX_BUFFER = 1024 * 1024
+
+type ProbeKind = keyof DeviceCapabilitySnapshot['errors']
+type Executor = (file: string, args: string[], timeout?: number, maxBuffer?: number) => Promise<CommandOutput>
+type Resolver = (runtime: RuntimeConfig, binary: 'scrcpy' | 'adb') => Promise<string>
+
+interface CacheEntry {
+  expiresAt: number
+  snapshot: DeviceCapabilitySnapshot
+}
+
+function numbers(value = ''): number[] {
+  if (!value.trim()) return []
+  return value.split(',').map((item) => Number(item.trim())).filter((item) => Number.isFinite(item))
+}
+
+function message(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).trim().slice(0, 1_000) || 'Probe failed.'
+}
+
+export function parseEncoderList(output: string): EncoderInfo[] {
+  const result: EncoderInfo[] = []
+  const pattern = /--(video|audio)-codec=([^\s]+)\s+--\1-encoder=([^\s]+)([^\r\n]*)/g
+  for (const match of output.matchAll(pattern)) {
+    const metadata = match[4] || ''
+    const implementation = metadata.match(/\((hw|sw|hybrid)\)/)?.[1] as EncoderInfo['implementation'] | undefined
+    result.push({
+      kind: match[1] as EncoderInfo['kind'], codec: match[2], name: match[3],
+      implementation: implementation || 'unknown', vendor: metadata.includes('[vendor]'),
+      aliasFor: metadata.match(/\(alias for ([^)]+)\)/)?.[1]
+    })
+  }
+  return result
+}
+
+export function parseDisplayList(output: string): DisplayInfo[] {
+  return [...output.matchAll(/--display-id=(\d+)\s+\((?:(\d+)x(\d+)|size unknown)\)/g)].map((match) => ({
+    id: Number(match[1]),
+    ...(match[2] && match[3] ? { width: Number(match[2]), height: Number(match[3]) } : {})
+  }))
+}
+
+function cameraHeader(line: string): CameraInfo | undefined {
+  const match = line.match(/--camera-id=([^\s]+)\s+\((front|back|external|unknown),\s*(\d+)x(\d+)(?:,\s*fps=\{([^}]*)\})?(?:,\s*zoom-range=\[([^,\]]+),\s*([^\]]+)\])?\)/)
+  if (!match) return undefined
+  const zoomMin = Number(match[6])
+  const zoomMax = Number(match[7])
+  return {
+    id: match[1], facing: match[2] as CameraInfo['facing'], sensorWidth: Number(match[3]), sensorHeight: Number(match[4]),
+    fps: numbers(match[5]),
+    ...(Number.isFinite(zoomMin) && Number.isFinite(zoomMax) ? { zoomRange: { min: zoomMin, max: zoomMax } } : {}),
+    sizes: []
+  }
+}
+
+export function parseCameraList(output: string): CameraInfo[] {
+  const cameras: CameraInfo[] = []
+  let current: CameraInfo | undefined
+  let highSpeed = false
+  for (const line of output.split(/\r?\n/)) {
+    const header = cameraHeader(line)
+    if (header) {
+      current = header
+      cameras.push(current)
+      highSpeed = false
+      continue
+    }
+    if (!current) continue
+    if (line.includes('High speed capture (--camera-high-speed)')) {
+      highSpeed = true
+      continue
+    }
+    const size = line.match(/-\s+(\d+)x(\d+)(?:\s+\(fps=\{([^}]*)\}\))?/)
+    if (!size) continue
+    const entry: CameraSizeInfo = {
+      width: Number(size[1]), height: Number(size[2]), highSpeed, fps: numbers(size[3])
+    }
+    if (!current.sizes.some((item) =>
+      item.width === entry.width && item.height === entry.height && item.highSpeed === entry.highSpeed
+    )) current.sizes.push(entry)
+  }
+  return cameras
+}
+
+function mergeCameras(base: CameraInfo[], detailed: CameraInfo[]): CameraInfo[] {
+  const merged = new Map(base.map((camera) => [camera.id, structuredClone(camera)]))
+  for (const camera of detailed) {
+    const existing = merged.get(camera.id)
+    merged.set(camera.id, existing
+      ? { ...existing, ...structuredClone(camera), sizes: structuredClone(camera.sizes) }
+      : structuredClone(camera))
+  }
+  return [...merged.values()]
+}
+
+export class DeviceCapabilityService {
+  private readonly cache = new Map<string, CacheEntry>()
+
+  constructor(
+    private readonly run: Executor = executeCommand,
+    private readonly resolve: Resolver = resolveBinary,
+    private readonly now = () => Date.now()
+  ) {}
+
+  async probe(runtime: RuntimeConfig, serial: string, refresh = false): Promise<DeviceCapabilitySnapshot> {
+    const executable = await this.resolve(runtime, 'scrcpy')
+    if (!executable) throw new Error('scrcpy executable not found.')
+    const key = `${executable}\0${serial}`
+    const cached = this.cache.get(key)
+    if (!refresh && cached && cached.expiresAt > this.now()) {
+      return { ...structuredClone(cached.snapshot), cached: true }
+    }
+    if (cached) this.cache.delete(key)
+
+    const outputs: Partial<Record<ProbeKind, string>> = {}
+    const errors: DeviceCapabilitySnapshot['errors'] = {}
+    const commands: Array<[ProbeKind, string]> = [
+      ['encoders', '--list-encoders'], ['displays', '--list-displays'],
+      ['cameras', '--list-cameras'], ['cameraSizes', '--list-camera-sizes']
+    ]
+    for (const [kind, flag] of commands) {
+      try {
+        const result = await this.run(
+          executable, [`--serial=${serial}`, flag], PROBE_TIMEOUT_MS, PROBE_MAX_BUFFER
+        )
+        outputs[kind] = `${result.stdout}\n${result.stderr}`
+        if (outputs[kind]?.includes('(access denied)')) errors[kind] = 'Android denied camera access.'
+      } catch (error) {
+        errors[kind] = message(error)
+      }
+    }
+
+    const encoders = parseEncoderList(outputs.encoders || '')
+    const snapshot: DeviceCapabilitySnapshot = {
+      serial,
+      capturedAt: new Date(this.now()).toISOString(),
+      cached: false,
+      videoEncoders: encoders.filter((encoder) => encoder.kind === 'video'),
+      audioEncoders: encoders.filter((encoder) => encoder.kind === 'audio'),
+      displays: parseDisplayList(outputs.displays || ''),
+      cameras: mergeCameras(parseCameraList(outputs.cameras || ''), parseCameraList(outputs.cameraSizes || '')),
+      errors
+    }
+    if (this.cache.size >= MAX_CACHE_ENTRIES) this.cache.delete(this.cache.keys().next().value as string)
+    this.cache.set(key, { expiresAt: this.now() + CACHE_TTL_MS, snapshot: structuredClone(snapshot) })
+    return snapshot
+  }
+
+  clear(): void {
+    this.cache.clear()
+  }
+}
+
+export const deviceCapabilityService = new DeviceCapabilityService()

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -61,6 +61,7 @@ import { deviceWorkspaceService, validatePackageId, validateRemoteDirectory, typ
 import { ArtifactService } from './artifactService'
 import { diagnosticsService, type DiagnosticContext, type PreparedDiagnostics } from './diagnosticsService'
 import { profileTransferService } from './profileTransferService'
+import { deviceCapabilityService } from './deviceCapabilityService'
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
@@ -98,6 +99,7 @@ function domainForChannel(channel: string): 'runtime' | 'device' | 'session' | '
   if (channel.startsWith('device:')) return 'device'
   if (channel.startsWith('session:') || channel.startsWith('scrcpy:')) return 'session'
   if (channel.startsWith('config:') || channel.startsWith('profile:')) return 'config'
+  if (channel.startsWith('capability:')) return 'runtime'
   return 'runtime'
 }
 
@@ -610,6 +612,21 @@ handle('profile:import-commit', (
   }
 })
 handle('system:environment', (_event, runtime: RuntimeConfig) => getEnvironment(runtimeConfig(runtime)))
+handle('capability:device-probe', async (_event, runtime: RuntimeConfig, serial: string, refresh = false) => {
+  try {
+    return {
+      ok: true,
+      data: await deviceCapabilityService.probe(
+        runtimeConfig(runtime), deviceSerial(serial), strictBoolean(refresh, 'refresh capabilities')
+      )
+    }
+  } catch (error) {
+    return failureFromUnknown(error, 'CAPABILITY_PROBE_FAILED', 'capability-probe', 'Unable to inspect device capabilities.', {
+      retryable: true,
+      suggestedActions: ['Confirm that the device is online.', 'Recheck the selected scrcpy runtime.']
+    })
+  }
+})
 handle('device:list', (_event, runtime: RuntimeConfig) => listDevices(runtimeConfig(runtime)))
 handle('device:track', (_event, runtime: RuntimeConfig) => startDeviceTracker(runtimeConfig(runtime)))
 handle('device:visibility', (_event, visible: boolean) => setDeviceTrackerVisibility(strictBoolean(visible, 'window visibility')))

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -69,6 +69,8 @@ const api: ScrcpyApi = {
   previewProfileImport: (runtime: RuntimeConfig) => ipcRenderer.invoke('profile:import-preview', runtime),
   commitProfileImport: (token: string, strategy: ProfileImportStrategy, keepMachinePaths: boolean) =>
     ipcRenderer.invoke('profile:import-commit', token, strategy, keepMachinePaths),
+  probeDeviceCapabilities: (runtime: RuntimeConfig, serial: string, refresh = false) =>
+    ipcRenderer.invoke('capability:device-probe', runtime, serial, refresh),
   setMinimizeToTray: (enabled: boolean) => ipcRenderer.invoke('app:minimize-to-tray', enabled),
   setQuitBehavior: (runtime: RuntimeConfig, killAdbOnQuit: boolean) =>
     ipcRenderer.invoke('app:quit-behavior', runtime, killAdbOnQuit),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -487,6 +487,49 @@ export interface CapabilitySnapshot {
   }
 }
 
+export interface EncoderInfo {
+  kind: 'video' | 'audio'
+  codec: string
+  name: string
+  implementation: 'hw' | 'sw' | 'hybrid' | 'unknown'
+  vendor: boolean
+  aliasFor?: string
+}
+
+export interface DisplayInfo {
+  id: number
+  width?: number
+  height?: number
+}
+
+export interface CameraSizeInfo {
+  width: number
+  height: number
+  highSpeed: boolean
+  fps: number[]
+}
+
+export interface CameraInfo {
+  id: string
+  facing: 'front' | 'back' | 'external' | 'unknown'
+  sensorWidth: number
+  sensorHeight: number
+  fps: number[]
+  zoomRange?: { min: number; max: number }
+  sizes: CameraSizeInfo[]
+}
+
+export interface DeviceCapabilitySnapshot {
+  serial: string
+  capturedAt: string
+  cached: boolean
+  videoEncoders: EncoderInfo[]
+  audioEncoders: EncoderInfo[]
+  displays: DisplayInfo[]
+  cameras: CameraInfo[]
+  errors: Partial<Record<'encoders' | 'displays' | 'cameras' | 'cameraSizes', string>>
+}
+
 export interface OperationResult<T = undefined> {
   ok: boolean
   data?: T
@@ -551,6 +594,7 @@ export interface ScrcpyApi {
   exportProfile(profile: LaunchProfile): Promise<OperationResult<string>>
   previewProfileImport(runtime: RuntimeConfig): Promise<OperationResult<ProfileImportPreview>>
   commitProfileImport(token: string, strategy: ProfileImportStrategy, keepMachinePaths: boolean): Promise<OperationResult<ProfileImportCommit>>
+  probeDeviceCapabilities(runtime: RuntimeConfig, serial: string, refresh?: boolean): Promise<OperationResult<DeviceCapabilitySnapshot>>
   setMinimizeToTray(enabled: boolean): Promise<void>
   setQuitBehavior(runtime: RuntimeConfig, killAdbOnQuit: boolean): Promise<void>
   setBossKey(enabled: boolean, accelerator: string): Promise<OperationResult<string>>

--- a/tests/deviceCapabilityService.test.ts
+++ b/tests/deviceCapabilityService.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeConfig } from '../src/shared/types'
+import {
+  DeviceCapabilityService,
+  parseCameraList,
+  parseDisplayList,
+  parseEncoderList
+} from '../src/main/deviceCapabilityService'
+
+const encoders = `[server] INFO: List of video encoders:
+    --video-codec=h264 --video-encoder=c2.android.avc.encoder             (sw)
+    --video-codec=h264 --video-encoder=OMX.qcom.video.encoder.avc        (hw) [vendor]
+[server] INFO: List of audio encoders:
+    --audio-codec=opus --audio-encoder=c2.android.opus.encoder           (sw) (alias for OMX.google.opus.encoder)
+`
+
+const displays = `[server] INFO: List of displays:
+    --display-id=0    (1080x2400)
+    --display-id=7    (size unknown)
+`
+
+const cameras = `[server] INFO: List of cameras:
+    --camera-id=0    (back, 4032x3024, fps={15, 30, 60}, zoom-range=[1, 8])
+    --camera-id=1    (front, 1920x1080, fps={30}, zoom-range=[1, 4])
+`
+
+const cameraSizes = `[server] INFO: List of cameras:
+    --camera-id=0    (back, 4032x3024, fps={15, 30, 60}, zoom-range=[1, 8])
+        - 1920x1080
+        - 1280x720
+      High speed capture (--camera-high-speed):
+        - 1920x1080 (fps={120, 240})
+    --camera-id=1    (front, 1920x1080, fps={30}, zoom-range=[1, 4])
+        - 1280x720
+`
+
+describe('scrcpy capability output parsers', () => {
+  it('parses encoder implementation, vendor and alias metadata', () => {
+    expect(parseEncoderList(encoders)).toEqual([
+      { kind: 'video', codec: 'h264', name: 'c2.android.avc.encoder', implementation: 'sw', vendor: false, aliasFor: undefined },
+      { kind: 'video', codec: 'h264', name: 'OMX.qcom.video.encoder.avc', implementation: 'hw', vendor: true, aliasFor: undefined },
+      { kind: 'audio', codec: 'opus', name: 'c2.android.opus.encoder', implementation: 'sw', vendor: false, aliasFor: 'OMX.google.opus.encoder' }
+    ])
+  })
+
+  it('parses known and unknown display sizes', () => {
+    expect(parseDisplayList(displays)).toEqual([
+      { id: 0, width: 1080, height: 2400 }, { id: 7 }
+    ])
+  })
+
+  it('associates normal and high-speed sizes with their cameras', () => {
+    expect(parseCameraList(cameraSizes)).toMatchObject([
+      {
+        id: '0', facing: 'back', sensorWidth: 4032, sensorHeight: 3024, fps: [15, 30, 60],
+        zoomRange: { min: 1, max: 8 },
+        sizes: [
+          { width: 1920, height: 1080, highSpeed: false, fps: [] },
+          { width: 1280, height: 720, highSpeed: false, fps: [] },
+          { width: 1920, height: 1080, highSpeed: true, fps: [120, 240] }
+        ]
+      },
+      { id: '1', facing: 'front', sizes: [{ width: 1280, height: 720, highSpeed: false, fps: [] }] }
+    ])
+  })
+})
+
+describe('DeviceCapabilityService', () => {
+  it('runs bounded argv-only probes sequentially, merges results and caches per runtime/device', async () => {
+    let time = Date.parse('2026-08-15T13:00:00.000Z')
+    const run = vi.fn(async (_file: string, args: string[], _timeout?: number, _maxBuffer?: number) => {
+      const output: Record<string, string> = {
+        '--list-encoders': encoders,
+        '--list-displays': displays,
+        '--list-cameras': cameras,
+        '--list-camera-sizes': cameraSizes
+      }
+      return { stdout: '', stderr: output[args[1]] || '' }
+    })
+    const service = new DeviceCapabilityService(
+      run,
+      async () => '/runtime/scrcpy',
+      () => time
+    )
+    const runtime: RuntimeConfig = { scrcpyPath: '/runtime/scrcpy' }
+    const first = await service.probe(runtime, 'SERIAL-1')
+
+    expect(run.mock.calls.map((call) => call[1])).toEqual([
+      ['--serial=SERIAL-1', '--list-encoders'],
+      ['--serial=SERIAL-1', '--list-displays'],
+      ['--serial=SERIAL-1', '--list-cameras'],
+      ['--serial=SERIAL-1', '--list-camera-sizes']
+    ])
+    expect(run.mock.calls.every((call) => call[2] === 20_000 && call[3] === 1024 * 1024)).toBe(true)
+    expect(first).toMatchObject({
+      serial: 'SERIAL-1', capturedAt: '2026-08-15T13:00:00.000Z', cached: false,
+      videoEncoders: [{ name: 'c2.android.avc.encoder' }, { name: 'OMX.qcom.video.encoder.avc' }],
+      audioEncoders: [{ name: 'c2.android.opus.encoder' }],
+      displays: [{ id: 0, width: 1080, height: 2400 }, { id: 7 }],
+      cameras: [{ id: '0', sizes: expect.any(Array) }, { id: '1', sizes: expect.any(Array) }]
+    })
+
+    time += 60_000
+    expect((await service.probe(runtime, 'SERIAL-1')).cached).toBe(true)
+    expect(run).toHaveBeenCalledTimes(4)
+    await service.probe(runtime, 'SERIAL-1', true)
+    expect(run).toHaveBeenCalledTimes(8)
+  })
+
+  it('returns partial data and per-probe errors instead of hiding successful probes', async () => {
+    const service = new DeviceCapabilityService(
+      async (_file, args) => {
+        if (args[1] === '--list-camera-sizes') throw new Error('camera service unavailable')
+        if (args[1] === '--list-cameras') return { stdout: '', stderr: 'List of cameras:\n    (access denied)' }
+        return { stdout: '', stderr: args[1] === '--list-displays' ? displays : encoders }
+      },
+      async () => '/runtime/scrcpy'
+    )
+    const snapshot = await service.probe({ scrcpyPath: '' }, 'SERIAL-2')
+    expect(snapshot.displays).toEqual([{ id: 0, width: 1080, height: 2400 }, { id: 7 }])
+    expect(snapshot.videoEncoders).toHaveLength(2)
+    expect(snapshot.cameras).toEqual([])
+    expect(snapshot.errors).toEqual({
+      cameras: 'Android denied camera access.',
+      cameraSizes: 'camera service unavailable'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- probe scrcpy 4.1 encoder, display, camera, and camera-size commands from the main process with argv-only execution and strict timeout/output bounds
- parse the exact upstream LogUtils output into typed video/audio encoders, display dimensions, camera facing/sensor/fps/zoom, and normal/high-speed sizes
- cache per runtime/device for five minutes with explicit refresh and bounded entry count
- preserve partial results and report per-probe failures, including Android camera access denial
- expose one validated narrow IPC method for future scene wizards

## Validation
- `npm test` — 154 tests passed
- `npm run build` — typecheck and production build passed
- parser fixtures mirror Genymobile/scrcpy v4.1 `LogUtils.java` output