### PR TITLE
chore: prepare v2.4.0 stable release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Checks
       options:
-        - label: I reproduced this with the latest Scrcpy GUI beta and scrcpy 4.x.
+        - label: I reproduced this with the latest stable Scrcpy GUI and bundled scrcpy 4.1 (or documented my custom runtime).
           required: true
         - label: I searched existing issues for the same error.
           required: true
@@ -16,7 +16,7 @@ body:
   - type: input
     attributes:
       label: Scrcpy GUI version
-      placeholder: 2.0.0-beta.1
+      placeholder: 2.4.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: ${{ matrix.command }}
+      - name: Smoke packaged bundled runtime
+        run: npm run smoke:packaged-runtime
       - name: Build Chocolatey package
         if: runner.os == 'Windows'
         shell: pwsh
@@ -70,11 +72,21 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
+      - name: Generate SHA-256 manifest
+        shell: bash
+        run: |
+          find artifacts -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            | awk '{ name=$2; sub(/^.*\//, "", name); print $1 "  " name }' \
+            | sort -k2 > SHA256SUMS.txt
       - uses: softprops/action-gh-release@v3
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
-          files: artifacts/**/*
+          files: |
+            artifacts/**/*
+            SHA256SUMS.txt
 
   publish-chocolatey:
     needs: [package, publish]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.4.0
+
+This is the first stable release of the rebuilt Scrcpy GUI. It completes the M0–M4 software roadmap with the scrcpy 4.1 scene model, device workspace, local diagnostics, device groups, and bounded multi-device automation. See the release smoke report for the hardware, signing, and installer verification gaps that remain explicit rather than inferred.
+
 ### Added
 
 - Model Camera, Virtual display, Record-only, Control-only, and OTG as validated launch scenes with official scrcpy 4.1 argv serialization, explicit conflicts, and portable Profile support.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/SimonAKing/scrcpy-gui/actions/workflows/validate.yml"><img src="https://github.com/SimonAKing/scrcpy-gui/actions/workflows/validate.yml/badge.svg" alt="Validate"></a>
-  <a href="https://github.com/SimonAKing/scrcpy-gui/releases"><img src="https://img.shields.io/github/v/release/SimonAKing/scrcpy-gui?include_prereleases&style=flat-square" alt="Latest release"></a>
+  <a href="https://github.com/SimonAKing/scrcpy-gui/releases"><img src="https://img.shields.io/github/v/release/SimonAKing/scrcpy-gui?style=flat-square" alt="Latest stable release"></a>
   <a href="https://github.com/SimonAKing/scrcpy-gui/releases"><img src="https://img.shields.io/github/downloads/SimonAKing/scrcpy-gui/total.svg?style=flat-square" alt="Downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/SimonAKing/scrcpy-gui?style=flat-square" alt="GPL-3.0"></a>
   <a href="https://github.com/SimonAKing/scrcpy-gui/issues"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square" alt="Contributions welcome"></a>
@@ -15,7 +15,7 @@
 
 Scrcpy GUI discovers Android devices over USB or wireless debugging and launches [scrcpy](https://github.com/Genymobile/scrcpy) with a reliable, visual configuration. It supports several devices at once, recording, audio, modern keyboard modes, cropping, window placement, and the current scrcpy 4.x command line.
 
-> Version 2.0 is a ground-up modernization and is currently in beta. When reporting a regression, please include the Logs tab output, your operating system, and your scrcpy version.
+> Version 2.4 is the first stable release of the ground-up modernization. When reporting a regression, please include the Logs tab output, your operating system, and your scrcpy version.
 
 ## Interface
 
@@ -72,7 +72,9 @@ Download the package for your platform from [GitHub Releases](https://github.com
 - **macOS:** Intel or Apple Silicon `.dmg` / `.zip`
 - **Linux:** `.AppImage`, Debian (`.deb`), Arch (`.pacman`), or portable `.tar.gz`
 
-The current beta artifacts are not code-signed or notarized. Your operating system may ask you to confirm that you trust the downloaded application.
+The current stable artifacts are not code-signed or notarized. Your operating system may ask you to confirm that you trust the downloaded application. Verify the download against the release `SHA256SUMS.txt` before opening it.
+
+The exact automated checks and unverified hardware/installer matrix are recorded in the [v2.4.0 release smoke report](docs/RELEASE_SMOKE_V2.4.0.md).
 
 ### Use another scrcpy installation
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/SimonAKing/scrcpy-gui/actions/workflows/validate.yml"><img src="https://github.com/SimonAKing/scrcpy-gui/actions/workflows/validate.yml/badge.svg" alt="Validate"></a>
-  <a href="https://github.com/SimonAKing/scrcpy-gui/releases"><img src="https://img.shields.io/github/v/release/SimonAKing/scrcpy-gui?include_prereleases&style=flat-square" alt="最新版本"></a>
+  <a href="https://github.com/SimonAKing/scrcpy-gui/releases"><img src="https://img.shields.io/github/v/release/SimonAKing/scrcpy-gui?style=flat-square" alt="最新稳定版"></a>
   <a href="https://github.com/SimonAKing/scrcpy-gui/releases"><img src="https://img.shields.io/github/downloads/SimonAKing/scrcpy-gui/total.svg?style=flat-square" alt="下载量"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/SimonAKing/scrcpy-gui?style=flat-square" alt="GPL-3.0"></a>
   <a href="https://github.com/SimonAKing/scrcpy-gui/issues"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square" alt="欢迎贡献"></a>
@@ -15,7 +15,7 @@
 
 Scrcpy GUI 可以发现通过 USB 或无线调试连接的 Android 设备，并通过可靠的图形配置启动 [scrcpy](https://github.com/Genymobile/scrcpy)。它支持同时投屏多台设备、录制、音频、现代键盘模式、画面裁剪、窗口布局和当前 scrcpy 4.x 命令行参数。
 
-> 2.0 是一次从底层重建的现代化版本，目前处于 Beta。反馈回归问题时，请附上「日志」页内容、操作系统和 scrcpy 版本。
+> 2.4 是从底层重建后的首个正式稳定版。反馈回归问题时，请附上「日志」页内容、操作系统和 scrcpy 版本。
 
 ## 界面
 
@@ -72,7 +72,9 @@ scrcpy 是 Genymobile 维护的高性能轻量工具。它可以通过 USB 或 T
 - **macOS：**Intel 或 Apple 芯片版本的 `.dmg` / `.zip`
 - **Linux：**`.AppImage`、Debian（`.deb`）、Arch（`.pacman`）或免安装 `.tar.gz`
 
-当前 Beta 构建尚未进行代码签名或公证，操作系统可能会要求你确认信任该应用。
+当前正式版构建尚未进行代码签名或公证，操作系统可能会要求你确认信任该应用。打开前请使用 Release 中的 `SHA256SUMS.txt` 校验下载文件。
+
+本次实际执行的自动检查，以及尚未验证的硬件/安装矩阵，记录在 [v2.4.0 Release smoke 报告](docs/RELEASE_SMOKE_V2.4.0.md)中。
 
 ### 使用其他 scrcpy 安装
 

--- a/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
+++ b/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
@@ -6,11 +6,11 @@
 >
 > 调研基线：2026-08-15
 >
-> 适用代码基线：`v2.0.0-beta.3` 及之后版本
+> 适用代码基线：`v2.4.0` 及之后版本
 >
 > 维护者：Simon Ma 与 Scrcpy GUI contributors
 
-> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地，真实 Camera/Virtual display/V4L2/OTG 硬件烟测仍待对应设备与平台。M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。M0 的三平台真实设备矩阵、Chocolatey 社区审核和 Stable 验收仍待外部条件完成。
+> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。v2.4.0 Stable 候选已加入三平台打包、包内 scrcpy/ADB 执行烟测和 SHA-256 清单门槛；真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、逐平台安装升级卸载与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
 
 ## 0. 文档目的
 

--- a/docs/RELEASE_SMOKE_V2.4.0.md
+++ b/docs/RELEASE_SMOKE_V2.4.0.md
@@ -1,0 +1,40 @@
+# v2.4.0 Release verification
+
+This record separates evidence collected before the tag from checks that run only on the tag workflow. A missing item is not inferred as passing.
+
+## Verified before tagging
+
+- `npm run typecheck`
+- `npm test -- --run`: 19 test files, 174 tests
+- `npm run build`
+- GitHub Validate matrix on PR #187: Ubuntu, macOS, and Windows passed
+- Electron/Chromium layout checks at 880×640, 1120×780, 1440×900, and device scale factor 2
+- No page-level horizontal overflow or off-screen form controls in the checked views; the preflight table owns its horizontal scrolling
+- locally built `Scrcpy.GUI-2.4.0-mac-arm64.zip` was extracted by `npm run smoke:packaged-runtime`
+- packaged macOS arm64 `scrcpy --version`: scrcpy 4.1
+- packaged macOS arm64 `adb version`: Android Debug Bridge 1.0.41, platform-tools 37.0.0
+- no Android device was attached to the release host
+
+## Tag workflow gates
+
+The `v2.4.0` tag is publishable only after the Release workflow:
+
+1. runs the complete test suite on the macOS, Windows, and Linux packaging jobs;
+2. downloads the checksum-pinned official scrcpy 4.1 bundle;
+3. builds every configured installer/archive;
+4. extracts the current-architecture archive on each host and executes its packaged `scrcpy --version` and `adb version`;
+5. uploads every package plus `SHA256SUMS.txt`;
+6. leaves Chocolatey Community publishing conditional on the real `CHOCO_API_KEY` secret.
+
+Expected assets are four macOS files, five Windows files plus `.nupkg`, four Linux files, and one checksum manifest (15 total). The release is not accepted if the workflow fails, the asset count differs, or any manifest entry does not match its uploaded file.
+
+## Explicitly unverified in this release run
+
+- physical Android screen/audio/recording and multi-device sessions;
+- Camera, Virtual display, V4L2, Control-only, and OTG hardware paths;
+- Android 11+ pairing/mDNS against a physical device;
+- manual install, upgrade, and uninstall behavior on each host OS;
+- code signing, Apple notarization, and Windows publisher reputation;
+- Chocolatey Community moderation/availability until the external repository accepts the package.
+
+These gaps are release-note disclosures, not claims that the features fail. They are also not converted into support claims from fake-binary, parser, or CI packaging evidence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.6",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-gui",
-      "version": "2.0.0-beta.6",
+      "version": "2.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vue": "^3.5.41"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.0.0-beta.6",
+  "version": "2.4.0",
   "description": "A modern, secure desktop GUI for scrcpy",
   "author": "Simon Ma <simon@tomotoes.com>",
   "homepage": "https://github.com/SimonAKing/scrcpy-gui",
@@ -23,6 +23,7 @@
     "icons:generate": "node scripts/generate-icons.mjs",
     "icons:check": "node scripts/generate-icons.mjs --check",
     "prepare:scrcpy": "node scripts/fetch-scrcpy.mjs",
+    "smoke:packaged-runtime": "node scripts/smoke-packaged-runtime.mjs",
     "build:dir": "npm run build && npm run prepare:scrcpy && electron-builder --dir",
     "dist": "npm run build && npm run prepare:scrcpy && electron-builder --publish never",
     "dist:mac": "npm run build && node scripts/fetch-scrcpy.mjs darwin && electron-builder --mac --x64 --arm64 --publish never",

--- a/packaging/chocolatey/scrcpy-gui.nuspec
+++ b/packaging/chocolatey/scrcpy-gui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scrcpy-gui</id>
-    <version>2.0.0-beta.6</version>
+    <version>2.4.0</version>
     <title>Scrcpy GUI</title>
     <authors>Simon Ma and contributors</authors>
     <owners>SimonAKing</owners>

--- a/scripts/smoke-packaged-runtime.mjs
+++ b/scripts/smoke-packaged-runtime.mjs
@@ -1,0 +1,53 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join, resolve, sep } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const projectRoot = resolve(import.meta.dirname, '..')
+const releaseDirectory = join(projectRoot, 'release')
+const archiveSuffix = process.platform === 'darwin'
+  ? `-mac-${process.arch}.zip`
+  : process.platform === 'win32'
+    ? `-win-${process.arch}.zip`
+    : `-linux-${process.arch}.tar.gz`
+
+async function walk(directory) {
+  const result = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) result.push(...await walk(path))
+    else if (entry.isFile()) result.push(path)
+  }
+  return result
+}
+
+function run(executable, args, expected) {
+  const result = spawnSync(executable, args, { encoding: 'utf8', windowsHide: true })
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim()
+  if (result.error || result.status !== 0 || !expected.test(output)) {
+    throw new Error(`Packaged runtime smoke failed for ${basename(executable)} (${result.status ?? 'spawn error'}).\n${output}\n${result.error || ''}`)
+  }
+  console.log(output.split(/\r?\n/)[0])
+}
+
+const archive = (await readdir(releaseDirectory))
+  .find((name) => name.startsWith('Scrcpy.GUI-') && name.endsWith(archiveSuffix))
+if (!archive) throw new Error(`No current-architecture packaged archive matches *${archiveSuffix}.`)
+
+const temporary = await mkdtemp(join(tmpdir(), 'scrcpy-gui-package-smoke-'))
+try {
+  const extraction = spawnSync('tar', ['-xf', join(releaseDirectory, archive), '-C', temporary], { stdio: 'inherit', windowsHide: true })
+  if (extraction.error || extraction.status !== 0) throw extraction.error || new Error(`Could not extract ${archive}.`)
+  const files = await walk(temporary)
+  const executableName = process.platform === 'win32' ? 'scrcpy.exe' : 'scrcpy'
+  const adbName = process.platform === 'win32' ? 'adb.exe' : 'adb'
+  const runtimeFile = (name) => files.find((path) => basename(path) === name && dirname(path).split(sep).includes('scrcpy'))
+  const scrcpy = runtimeFile(executableName)
+  const adb = runtimeFile(adbName)
+  if (!scrcpy || !adb) throw new Error('The packaged archive does not contain both scrcpy and adb under Resources/scrcpy.')
+  run(scrcpy, ['--version'], /^scrcpy\s+4\.1\b/im)
+  run(adb, ['version'], /^Android Debug Bridge version\s+1\.0\.41\b/im)
+  console.log(`Verified packaged runtime from ${archive}.`)
+} finally {
+  await rm(temporary, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- promote the completed M0-M4 software roadmap from beta.6 to the first stable `2.4.0` release
- update stable-channel documentation, issue metadata, Chocolatey metadata, and the changelog
- add a release smoke record that distinguishes verified software evidence from unavailable hardware/signing/installer checks
- require every tag job to extract its current-architecture package and execute the packaged scrcpy 4.1 and ADB 1.0.41
- publish a SHA-256 manifest alongside the 14 installers/archives (15 release assets total)

## Local verification

- `npm run typecheck`
- `npm test -- --run` (19 files, 174 tests)
- `npm run icons:check`
- `CSC_IDENTITY_AUTO_DISCOVERY=false npm run dist:mac`
- `npm run smoke:packaged-runtime` against `Scrcpy.GUI-2.4.0-mac-arm64.zip`
  - scrcpy 4.1
  - Android Debug Bridge 1.0.41 / platform-tools 37.0.0

## Release disclosures

The release remains unsigned/unnotarized. No Android device is attached to this host, so physical-device, Camera, Virtual display, V4L2, OTG, install/upgrade/uninstall, and Chocolatey moderation evidence are explicitly listed as unverified. The tag will only be created after this PR and its three-platform checks pass.