### PR TITLE
docs: record v2.4.0 release evidence

### DIFF
--- a/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
+++ b/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
@@ -1,6 +1,6 @@
 # Scrcpy GUI 产品与技术功能规格
 
-> 状态：提案（Proposed）
+> 状态：M0–M4 软件范围已实施（Implemented）
 >
 > 文档版本：1.0
 >
@@ -10,7 +10,7 @@
 >
 > 维护者：Simon Ma 与 Scrcpy GUI contributors
 
-> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。v2.4.0 Stable 候选已加入三平台打包、包内 scrcpy/ADB 执行烟测和 SHA-256 清单门槛；真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、逐平台安装升级卸载与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
+> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。[v2.4.0 Stable](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) 已正式发布：三平台 Release workflow、包内 scrcpy/ADB 执行烟测、15 个发布资产及 14 个包的 SHA-256 清单核对均通过；真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、逐平台安装升级卸载与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
 
 ## 0. 文档目的
 

--- a/docs/RELEASE_SMOKE_V2.4.0.md
+++ b/docs/RELEASE_SMOKE_V2.4.0.md
@@ -15,9 +15,9 @@ This record separates evidence collected before the tag from checks that run onl
 - packaged macOS arm64 `adb version`: Android Debug Bridge 1.0.41, platform-tools 37.0.0
 - no Android device was attached to the release host
 
-## Tag workflow gates
+## Published tag workflow result
 
-The `v2.4.0` tag is publishable only after the Release workflow:
+The [`v2.4.0` Release workflow](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31890315296) completed successfully on macOS, Windows, and Linux. It:
 
 1. runs the complete test suite on the macOS, Windows, and Linux packaging jobs;
 2. downloads the checksum-pinned official scrcpy 4.1 bundle;
@@ -26,7 +26,7 @@ The `v2.4.0` tag is publishable only after the Release workflow:
 5. uploads every package plus `SHA256SUMS.txt`;
 6. leaves Chocolatey Community publishing conditional on the real `CHOCO_API_KEY` secret.
 
-Expected assets are four macOS files, five Windows files plus `.nupkg`, four Linux files, and one checksum manifest (15 total). The release is not accepted if the workflow fails, the asset count differs, or any manifest entry does not match its uploaded file.
+The published [Scrcpy GUI 2.4.0 release](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) is neither a draft nor a prerelease. It contains four macOS files, five Windows files plus `.nupkg`, four Linux files, and one checksum manifest (15 assets total). All 14 package entries in `SHA256SUMS.txt` were matched against the corresponding uploaded asset digests. The optional Chocolatey Community step reported that `CHOCO_API_KEY` was not configured and correctly skipped the external push; issue #139 therefore remains open.
 
 ## Explicitly unverified in this release run
 


### PR DESCRIPTION
## Summary
- record the successful three-platform v2.4.0 release workflow
- link the stable release and its auditable asset/checksum result
- preserve the explicitly unverified hardware, signing, installer, and Chocolatey gaps

## Validation
- `git diff --check -- docs/RELEASE_SMOKE_V2.4.0.md docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md`
- release workflow: https://github.com/SimonAKing/scrcpy-gui/actions/runs/31890315296
- release: https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0