### PR TITLE
fix: compare Debian package versions correctly

### DIFF
--- a/.github/workflows/installer-lifecycle.yml
+++ b/.github/workflows/installer-lifecycle.yml
@@ -196,11 +196,16 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes "./downloads/Scrcpy.GUI-${PREVIOUS_VERSION}-linux-amd64.deb"
-          [[ "$(dpkg-query -W -f='${Version}' scrcpy-gui)" == "$PREVIOUS_VERSION" ]]
+          previous_deb="./downloads/Scrcpy.GUI-${PREVIOUS_VERSION}-linux-amd64.deb"
+          current_deb="./downloads/Scrcpy.GUI-${CURRENT_VERSION}-linux-amd64.deb"
+          previous_package_version="$(dpkg-deb --field "$previous_deb" Version)"
+          current_package_version="$(dpkg-deb --field "$current_deb" Version)"
 
-          sudo apt-get install --yes "./downloads/Scrcpy.GUI-${CURRENT_VERSION}-linux-amd64.deb"
-          [[ "$(dpkg-query -W -f='${Version}' scrcpy-gui)" == "$CURRENT_VERSION" ]]
+          sudo apt-get install --yes "$previous_deb"
+          [[ "$(dpkg-query -W -f='${Version}' scrcpy-gui)" == "$previous_package_version" ]]
+
+          sudo apt-get install --yes "$current_deb"
+          [[ "$(dpkg-query -W -f='${Version}' scrcpy-gui)" == "$current_package_version" ]]
           runtime="$(dpkg -L scrcpy-gui | awk '/\/resources\/scrcpy\/scrcpy$/ { print; exit }')"
           adb="$(dpkg -L scrcpy-gui | awk '/\/resources\/scrcpy\/adb$/ { print; exit }')"
           [[ -x "$runtime" && -x "$adb" ]]

--- a/docs/INSTALLER_LIFECYCLE_SMOKE.md
+++ b/docs/INSTALLER_LIFECYCLE_SMOKE.md
@@ -12,6 +12,8 @@ The `Installer lifecycle smoke` workflow validates real GitHub Release assets ra
 
 The current release asset must match its published `SHA256SUMS.txt` entry before installation. Version inputs are syntax-validated and downloads are restricted to this repository's releases.
 
+Linux comparisons use the `Version` field embedded in each Debian package. This is intentionally not compared directly with the Git tag because Debian encodes prerelease ordering with `~` (for example, tag `2.0.0-beta.6` becomes package version `2.0.0~beta.6`).
+
 ## Evidence and limits
 
 This workflow proves that representative native installer formats can install, upgrade, expose the expected bundled scrcpy/ADB runtime, and uninstall on clean hosted runners. It does not prove code-signing reputation, Apple notarization, interactive installer wording, retained user preferences, every Linux package format, physical Android behavior, or Chocolatey Community availability.


### PR DESCRIPTION
## Root cause
The first real installer lifecycle run proved that the beta.6 Debian package installed successfully as `2.0.0~beta.6`. The workflow incorrectly compared that Debian-native version to the Git tag input `2.0.0-beta.6`, so it exited before attempting the stable upgrade.

Failed evidence: https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892216091

## Fix
- read each package’s authoritative `Version` control field with `dpkg-deb --field`
- compare the installed version to that field after both install and upgrade
- document Debian prerelease normalization instead of weakening the assertion

## Validation
- `git diff --check`
- actionlint

## Acceptance
After merge, rerun the real beta.6 → v2.4.0 lifecycle workflow; Linux must pass alongside the already-passing macOS and Windows jobs.