### PR TITLE
docs: record installer lifecycle evidence

### DIFF
--- a/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
+++ b/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
@@ -10,7 +10,7 @@
 >
 > 维护者：Simon Ma 与 Scrcpy GUI contributors
 
-> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。[v2.4.0 Stable](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) 已正式发布：三平台 Release workflow、包内 scrcpy/ADB 执行烟测、15 个发布资产及 14 个包的 SHA-256 清单核对均通过；真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、逐平台安装升级卸载与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
+> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。[v2.4.0 Stable](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) 已正式发布：三平台 Release workflow、包内 scrcpy/ADB 执行烟测、15 个发布资产及 14 个包的 SHA-256 清单核对均通过；随后真实发布资产的 macOS DMG、Windows NSIS 与 Ubuntu Debian 安装 → 升级 → 卸载工作流也全部通过。真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、人工交互式安装体验与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
 
 ## 0. 文档目的
 

--- a/docs/RELEASE_SMOKE_V2.4.0.md
+++ b/docs/RELEASE_SMOKE_V2.4.0.md
@@ -28,12 +28,22 @@ The [`v2.4.0` Release workflow](https://github.com/SimonAKing/scrcpy-gui/actions
 
 The published [Scrcpy GUI 2.4.0 release](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) is neither a draft nor a prerelease. It contains four macOS files, five Windows files plus `.nupkg`, four Linux files, and one checksum manifest (15 assets total). All 14 package entries in `SHA256SUMS.txt` were matched against the corresponding uploaded asset digests. The optional Chocolatey Community step reported that `CHOCO_API_KEY` was not configured and correctly skipped the external push; issue #139 therefore remains open.
 
+## Published installer lifecycle result
+
+The post-release [`v2.0.0-beta.6` → `v2.4.0` installer lifecycle run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892365146) passed against downloaded GitHub Release assets:
+
+- macOS (13s): architecture-matching DMG mount, previous app copy to `/Applications`, stable replacement, bundle/runtime version checks, and removal;
+- Windows (33s): x64 NSIS silent previous install, stable upgrade, registry/runtime version checks, and registered silent uninstall;
+- Ubuntu (43s): amd64 Debian package install, stable upgrade using Debian-native version metadata, runtime checks, and package removal.
+
+Every current asset was matched to its published `SHA256SUMS.txt` entry before installation. Each installed package then executed bundled scrcpy 4.1 and ADB 1.0.41. This is hosted-runner lifecycle evidence, not a claim that interactive installer wording, signing reputation, or retained user preferences were manually reviewed.
+
 ## Explicitly unverified in this release run
 
 - physical Android screen/audio/recording and multi-device sessions;
 - Camera, Virtual display, V4L2, Control-only, and OTG hardware paths;
 - Android 11+ pairing/mDNS against a physical device;
-- manual install, upgrade, and uninstall behavior on each host OS;
+- manual interactive install, upgrade, and uninstall UX on each host OS;
 - code signing, Apple notarization, and Windows publisher reputation;
 - Chocolatey Community moderation/availability until the external repository accepts the package.
 


### PR DESCRIPTION
## Summary
- record the successful beta.6 → v2.4.0 published-asset installer lifecycle run
- distinguish automated native installer coverage from unverified manual interactive UX
- update the M0–M4 implementation evidence without broadening hardware/signing claims

## Evidence
- successful run: https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892365146
- macOS DMG: 13s
- Windows NSIS: 33s
- Ubuntu Debian: 43s

## Validation
- `git diff --check -- docs/RELEASE_SMOKE_V2.4.0.md docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md`