### PR TITLE
ci: launch installed renderer in lifecycle smoke

### DIFF
--- a/.github/workflows/installer-lifecycle.yml
+++ b/.github/workflows/installer-lifecycle.yml
@@ -54,8 +54,12 @@ jobs:
           set -euo pipefail
           target='/Applications/Scrcpy GUI.app'
           active_mount=''
+          app_pid=''
 
           cleanup() {
+            if [[ -n "$app_pid" ]]; then
+              kill "$app_pid" 2>/dev/null || true
+            fi
             if [[ -n "$active_mount" ]]; then
               hdiutil detach "$active_mount" -quiet || true
             fi
@@ -82,6 +86,24 @@ jobs:
 
           "$target/Contents/Resources/scrcpy/scrcpy" --version | grep -E '^scrcpy 4\.1'
           "$target/Contents/Resources/scrcpy/adb" version | grep -E '^Android Debug Bridge version 1\.0\.41'
+
+          "$target/Contents/MacOS/Scrcpy GUI" --remote-debugging-port=9222 > renderer.stdout.log 2> renderer.stderr.log &
+          app_pid=$!
+          renderer_ready='false'
+          for _ in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:9222/json/list | grep -q '"url": "file:'; then
+              renderer_ready='true'
+              break
+            fi
+            sleep 1
+          done
+          if [[ "$renderer_ready" != 'true' ]]; then
+            cat renderer.stdout.log renderer.stderr.log
+            exit 1
+          fi
+          kill "$app_pid"
+          wait "$app_pid" || true
+          app_pid=''
 
           sudo rm -rf '/Applications/Scrcpy GUI.app'
           test ! -e "$target"
@@ -163,6 +185,32 @@ jobs:
           if ((& $scrcpy --version | Select-Object -First 1) -notmatch '^scrcpy 4\.1') { throw 'Installed scrcpy version check failed.' }
           if ((& $adb version | Select-Object -First 1) -notmatch '^Android Debug Bridge version 1\.0\.41') { throw 'Installed adb version check failed.' }
 
+          $app = Join-Path $installLocation 'Scrcpy GUI.exe'
+          if (-not (Test-Path $app)) { throw 'Installed Scrcpy GUI executable is missing.' }
+          $appProcess = Start-Process -FilePath $app -ArgumentList '--remote-debugging-port=9222' -RedirectStandardOutput renderer.stdout.log -RedirectStandardError renderer.stderr.log -PassThru
+          try {
+            $rendererReady = $false
+            for ($attempt = 0; $attempt -lt 30; $attempt++) {
+              try {
+                $pages = Invoke-RestMethod http://127.0.0.1:9222/json/list
+                if ($pages | Where-Object { $_.type -eq 'page' -and $_.url -like 'file:*' }) {
+                  $rendererReady = $true
+                  break
+                }
+              } catch {
+                # The debug endpoint is not listening yet.
+              }
+              Start-Sleep -Seconds 1
+            }
+            if (-not $rendererReady) {
+              Get-Content renderer.stdout.log, renderer.stderr.log -ErrorAction SilentlyContinue
+              throw 'Installed Renderer did not expose a loaded file page.'
+            }
+          } finally {
+            Stop-Process -Id $appProcess.Id -Force -ErrorAction SilentlyContinue
+            $appProcess.WaitForExit()
+          }
+
           if ($current.UninstallString -notmatch '^"([^"]+)"') { throw 'Could not parse the registered uninstaller.' }
           $uninstaller = $Matches[1]
           $process = Start-Process -FilePath $uninstaller -ArgumentList '/S' -PassThru -Wait
@@ -196,6 +244,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
+          sudo apt-get install --yes xvfb
           previous_deb="./downloads/Scrcpy.GUI-${PREVIOUS_VERSION}-linux-amd64.deb"
           current_deb="./downloads/Scrcpy.GUI-${CURRENT_VERSION}-linux-amd64.deb"
           previous_package_version="$(dpkg-deb --field "$previous_deb" Version)"
@@ -211,6 +260,24 @@ jobs:
           [[ -x "$runtime" && -x "$adb" ]]
           "$runtime" --version | grep -E '^scrcpy 4\.1'
           "$adb" version | grep -E '^Android Debug Bridge version 1\.0\.41'
+
+          xvfb-run -a scrcpy-gui --no-sandbox --remote-debugging-port=9222 > renderer.stdout.log 2> renderer.stderr.log &
+          app_pid=$!
+          renderer_ready='false'
+          for _ in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:9222/json/list | grep -q '"url": "file:'; then
+              renderer_ready='true'
+              break
+            fi
+            sleep 1
+          done
+          if [[ "$renderer_ready" != 'true' ]]; then
+            cat renderer.stdout.log renderer.stderr.log
+            kill "$app_pid" 2>/dev/null || true
+            exit 1
+          fi
+          kill "$app_pid"
+          wait "$app_pid" || true
 
           sudo apt-get remove --yes scrcpy-gui
           status="$(dpkg-query -W -f='${db:Status-Status}' scrcpy-gui 2>/dev/null || true)"

--- a/docs/INSTALLER_LIFECYCLE_SMOKE.md
+++ b/docs/INSTALLER_LIFECYCLE_SMOKE.md
@@ -6,9 +6,9 @@ The `Installer lifecycle smoke` workflow validates real GitHub Release assets ra
 
 | Host | Published asset | Lifecycle |
 | --- | --- | --- |
-| macOS | architecture-matching DMG | mount, copy the previous app to `/Applications`, replace it with the current app, verify bundle/runtime versions, remove the app |
-| Windows | x64 NSIS installer | silent previous install, silent current upgrade, verify registry/runtime versions, registered silent uninstall |
-| Ubuntu | amd64 Debian package | `apt` previous install, `apt` current upgrade, verify dpkg/runtime versions, package removal |
+| macOS | architecture-matching DMG | mount, copy the previous app to `/Applications`, replace it with the current app, verify bundle/runtime versions and Renderer startup, remove the app |
+| Windows | x64 NSIS installer | silent previous install, silent current upgrade, verify registry/runtime versions and Renderer startup, registered silent uninstall |
+| Ubuntu | amd64 Debian package | `apt` previous install, `apt` current upgrade, verify dpkg/runtime versions and Xvfb Renderer startup, package removal |
 
 The current release asset must match its published `SHA256SUMS.txt` entry before installation. Version inputs are syntax-validated and downloads are restricted to this repository's releases.
 
@@ -16,6 +16,8 @@ Linux comparisons use the `Version` field embedded in each Debian package. This 
 
 ## Evidence and limits
 
-This workflow proves that representative native installer formats can install, upgrade, expose the expected bundled scrcpy/ADB runtime, and uninstall on clean hosted runners. It does not prove code-signing reputation, Apple notarization, interactive installer wording, retained user preferences, every Linux package format, physical Android behavior, or Chocolatey Community availability.
+After the current package is installed, the workflow launches its real Electron executable with a loopback-only Chromium debugging port and waits for a loaded `file://` Renderer page. The process is then terminated before the native uninstaller/removal step. Linux performs the same check under Xvfb.
+
+This workflow proves that representative native installer formats can install, upgrade, launch the packaged Renderer, expose the expected bundled scrcpy/ADB runtime, and uninstall on clean hosted runners. It does not prove code-signing reputation, Apple notarization, interactive installer wording, retained user preferences, every Linux package format, physical Android behavior, or Chocolatey Community availability.
 
 Record each accepted run URL and exact input versions in the corresponding release smoke report. A green build/package job is not a substitute for this lifecycle workflow.


### PR DESCRIPTION
## Evidence gap
The installer workflow proved package install/upgrade/runtime/uninstall, but M0 also requires basic startup on all three hosts. A build or `scrcpy --version` does not prove the installed Electron renderer loads.

## Change
- start the installed v2.4.0 executable on macOS and Windows
- start the installed Debian executable under Xvfb on Ubuntu
- use an ephemeral loopback Chromium debug port and require a loaded production `file://` page
- terminate the app before exercising the normal uninstall/removal path
- retain logs when startup does not become ready

## Static validation
- `git diff --check`
- actionlint

## Acceptance
After merge, the published beta.6 → v2.4.0 workflow must pass again on macOS, Windows, and Ubuntu. Only that run is startup evidence.