### PR TITLE
docs: record installed GUI startup evidence

### DIFF
--- a/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
+++ b/docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md
@@ -10,7 +10,7 @@
 >
 > 维护者：Simon Ma 与 Scrcpy GUI contributors
 
-> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。[v2.4.0 Stable](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) 已正式发布：三平台 Release workflow、包内 scrcpy/ADB 执行烟测、15 个发布资产及 14 个包的 SHA-256 清单核对均通过；随后真实发布资产的 macOS DMG、Windows NSIS 与 Ubuntu Debian 安装 → 升级 → 卸载工作流也全部通过。真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、人工交互式安装体验与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
+> 实施进度（2026-08-15）：M1 的 OptionDescriptor、CapabilityRegistry、命令预览、SessionManager、DeviceTracker、结构化事件/错误、Sessions 页面和 Config V3 已落地；M2 的设备工作区、文件推送、APK 安装、应用列表/启动、ArtifactService、脱敏诊断包、Issue helper 和 Profile 导入导出已落地；M3 的六类场景领域模型、官方 argv 序列化、场景冲突矩阵、Profile 往返、设备级编码器/显示/相机探测、响应式场景向导、输出预检和独立无 ADB OTG 流程已落地；M4 的设备组、场景/组预设、批量预检、逐设备结果、Automation V2 编辑/导入预览/取消、并发控制、确认门槛和产物化 run report 已落地，并已通过 fake ADB、迁移、安全验证与 880/1120/1440 视口检查。[v2.4.0 Stable](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.0) 已正式发布：三平台 Release workflow、包内 scrcpy/ADB 执行烟测、15 个发布资产及 14 个包的 SHA-256 清单核对均通过；随后真实发布资产的 macOS DMG、Windows NSIS 与 Ubuntu Debian 安装 → 升级 → 安装后 Renderer 启动 → 卸载工作流也全部通过。真实 Android/Camera/Virtual display/V4L2/OTG 硬件矩阵、签名/公证、人工交互式安装体验与 Chocolatey 社区审核仍是明确未验证项，必须保留在 Release notes，不能由 CI 推断为已完成。
 
 ## 0. 文档目的
 

--- a/docs/RELEASE_SMOKE_V2.4.0.md
+++ b/docs/RELEASE_SMOKE_V2.4.0.md
@@ -30,13 +30,13 @@ The published [Scrcpy GUI 2.4.0 release](https://github.com/SimonAKing/scrcpy-gu
 
 ## Published installer lifecycle result
 
-The post-release [`v2.0.0-beta.6` → `v2.4.0` installer lifecycle run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892365146) passed against downloaded GitHub Release assets:
+The post-release [`v2.0.0-beta.6` → `v2.4.0` installer lifecycle and startup run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892938302) passed against downloaded GitHub Release assets:
 
-- macOS (13s): architecture-matching DMG mount, previous app copy to `/Applications`, stable replacement, bundle/runtime version checks, and removal;
-- Windows (33s): x64 NSIS silent previous install, stable upgrade, registry/runtime version checks, and registered silent uninstall;
-- Ubuntu (43s): amd64 Debian package install, stable upgrade using Debian-native version metadata, runtime checks, and package removal.
+- macOS (22s): architecture-matching DMG mount, previous app copy to `/Applications`, stable replacement, installed Renderer startup, bundle/runtime version checks, and removal;
+- Windows (42s): x64 NSIS silent previous install, stable upgrade, installed Renderer startup, registry/runtime version checks, and registered silent uninstall;
+- Ubuntu (39s): amd64 Debian package install, stable upgrade using Debian-native version metadata, installed Renderer startup under Xvfb, runtime checks, and package removal.
 
-Every current asset was matched to its published `SHA256SUMS.txt` entry before installation. Each installed package then executed bundled scrcpy 4.1 and ADB 1.0.41. This is hosted-runner lifecycle evidence, not a claim that interactive installer wording, signing reputation, or retained user preferences were manually reviewed.
+Every current asset was matched to its published `SHA256SUMS.txt` entry before installation. Each installed package loaded its production `file://` Renderer through the real Electron executable, then executed bundled scrcpy 4.1 and ADB 1.0.41. This is hosted-runner lifecycle/startup evidence, not a claim that interactive installer wording, signing reputation, or retained user preferences were manually reviewed.
 
 ## Explicitly unverified in this release run
 


### PR DESCRIPTION
## Summary
- replace the earlier installer-only run with the stronger installed-GUI startup run
- record production Renderer readiness plus install/upgrade/runtime/uninstall on all three hosts
- preserve the explicit distinction from manual UX, hardware, and signing evidence

## Evidence
https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892938302

- macOS: 22s
- Windows: 42s
- Ubuntu/Xvfb: 39s

## Validation
- `git diff --check -- docs/RELEASE_SMOKE_V2.4.0.md docs/PRODUCT_TECHNICAL_SPEC.zh_CN.md`