### PR TITLE
test: add redacted physical hardware preflight

### DIFF
--- a/docs/HARDWARE_SMOKE_RUNBOOK.md
+++ b/docs/HARDWARE_SMOKE_RUNBOOK.md
@@ -1,0 +1,54 @@
+# Physical Android hardware smoke runbook
+
+This runbook closes hardware evidence gaps; it is not a simulator test and does not convert fake ADB output into a support claim.
+
+## 1. Generate the preflight report
+
+Connect and authorize one physical Android device, then run:
+
+```bash
+npm run prepare:scrcpy
+npm run smoke:hardware -- --output hardware-smoke-report.json
+```
+
+When more than one authorized device is attached, select one explicitly:
+
+```bash
+npm run smoke:hardware -- --serial SERIAL --output hardware-smoke-report.json
+```
+
+The tool exits successfully only for one selected, authorized, non-emulator target. It records host/Android metadata, display size, encoders, displays, cameras, and camera sizes. The report replaces the ADB serial with a stable short hash and redacts addresses and home paths. It never treats the capability probes as scene success.
+
+Do not commit a hardware report without reviewing it. Attach the reviewed report to the release evidence or test record instead.
+
+## 2. Execute every pending scene
+
+Use the same installed release package throughout the run. For every row, record `pass`, `fail`, `unsupported`, or `unavailable`, plus an artifact/log reference and a short observation.
+
+| Scene | Required observation |
+| --- | --- |
+| Screen | real display appears; keyboard/mouse control works; session stops cleanly |
+| Audio | forwarded audio is audible on a supported Android version; unsupported versions are recorded, not passed |
+| Record-only | output file is created, indexed, playable, and finalized after stop |
+| Camera | selected camera/size/fps starts or returns a structured device error |
+| Virtual display | selected app opens on the created display and close behavior matches the preview |
+| Control-only | input works with video/audio disabled and no false playback state |
+| OTG | control works through the no-ADB path; USB debugging is not used as evidence |
+| V4L2 | on Linux with `v4l2loopback`, the chosen sink receives frames; otherwise mark host unavailable |
+| Pairing/mDNS | Android 11+ pairing succeeds, connection address is remembered, and discovery reconnects |
+| Multi-device | two physical devices launch independently and partial failure is reported per device |
+
+Capture the Scrcpy GUI diagnostic ZIP and relevant screenshots/recordings after the run. Review redactions before sharing.
+
+## 3. Matrix metadata
+
+Record without raw serial numbers:
+
+- release version and package checksum;
+- host OS and architecture;
+- Android release/API, manufacturer, and model from the preflight report;
+- USB, legacy TCP/IP, or Android 11+ pairing connection;
+- scene outcome and artifact/log reference;
+- every unavailable vendor/Android/host cell.
+
+At least one physical device and one host must pass the M0 baseline. M3 additionally requires at least one real hardware run for every scene; a mode may be `unsupported` for a specific device, but that result must be preserved instead of silently omitted.

--- a/docs/M0_M4_COMPLETION_AUDIT.md
+++ b/docs/M0_M4_COMPLETION_AUDIT.md
@@ -107,3 +107,5 @@ Research remains intentionally unimplemented until a prototype, cross-platform m
 4. Keep signing/notarization and manual interactive installer UX disclosed until separately exercised; neither is inferred from hosted-runner startup.
 
 The separate MIT v2.4.1 Draft (#190) also requires explicit consent for the migrated #69 Russian translation and confirmation that maintainer-authored work is free of employer/school/IP restrictions. It is not counted as an M0–M4 completion claim.
+
+Use the [physical hardware smoke runbook](HARDWARE_SMOKE_RUNBOOK.md) and `npm run smoke:hardware` to generate the redacted preflight report and execute the remaining scene checklist. A `blocked` preflight report is evidence that prerequisites are missing, not evidence that a scene passed.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "icons:check": "node scripts/generate-icons.mjs --check",
     "prepare:scrcpy": "node scripts/fetch-scrcpy.mjs",
     "smoke:packaged-runtime": "node scripts/smoke-packaged-runtime.mjs",
+    "smoke:hardware": "node scripts/hardware-smoke.mjs",
     "build:dir": "npm run build && npm run prepare:scrcpy && electron-builder --dir",
     "dist": "npm run build && npm run prepare:scrcpy && electron-builder --publish never",
     "dist:mac": "npm run build && node scripts/fetch-scrcpy.mjs darwin && electron-builder --mac --x64 --arm64 --publish never",

--- a/scripts/hardware-smoke.mjs
+++ b/scripts/hardware-smoke.mjs
@@ -1,0 +1,253 @@
+import { createHash } from 'node:crypto'
+import { access, mkdir, open } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const MAX_OUTPUT = 12_000
+const TIMEOUT_MS = 20_000
+
+function bounded(value) {
+  const text = String(value || '').trim()
+  return text.length <= MAX_OUTPUT ? text : `${text.slice(0, MAX_OUTPUT)}\n[truncated]`
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function redactHardwareOutput(value, serial = '', home = homedir()) {
+  let result = bounded(value)
+  if (serial) result = result.replace(new RegExp(escapeRegex(serial), 'g'), '[device]')
+  if (home) result = result.replace(new RegExp(escapeRegex(home), 'g'), '[home]')
+  return result
+    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, '[address]')
+    .replace(/\b[0-9a-f]{0,4}:[0-9a-f:]{2,}(?:%[\w.-]+)?(?:\]:\d+)?\b/gi, '[address]')
+}
+
+export function parseAdbDevices(output) {
+  const devices = []
+  for (const line of String(output || '').split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('List of devices') || trimmed.startsWith('* daemon')) continue
+    const match = trimmed.match(/^(\S+)\s+(device|unauthorized|offline|no permissions)(?:\s+.*)?$/)
+    if (match) devices.push({ serial: match[1], state: match[2] })
+  }
+  return devices
+}
+
+function firstLine(value) {
+  return bounded(value).split(/\r?\n/).find((line) => line.trim())?.trim() || ''
+}
+
+function deviceId(serial) {
+  return `device-${createHash('sha256').update(serial).digest('hex').slice(0, 16)}`
+}
+
+function connectionKind(serial) {
+  if (serial.startsWith('emulator-')) return 'emulator'
+  return serial.includes(':') ? 'tcpip' : 'usb'
+}
+
+function defaultRun(file, args, timeout = TIMEOUT_MS) {
+  const child = spawnSync(file, args, {
+    encoding: 'utf8', timeout, maxBuffer: 1024 * 1024, windowsHide: true
+  })
+  return {
+    code: child.status ?? 1,
+    stdout: child.stdout || '',
+    stderr: `${child.stderr || ''}${child.error ? `\n${child.error.message}` : ''}`,
+    timedOut: child.error?.code === 'ETIMEDOUT'
+  }
+}
+
+function commandRecord(result, serial) {
+  return {
+    ok: result.code === 0 && !result.timedOut,
+    exitCode: result.code,
+    timedOut: Boolean(result.timedOut),
+    output: redactHardwareOutput(`${result.stdout || ''}\n${result.stderr || ''}`, serial)
+  }
+}
+
+function blockedReport(base, reason, discovery, target) {
+  return {
+    ...base, status: 'blocked', reason, discovery,
+    ...(target ? { target } : {}), probes: {}, checklist: []
+  }
+}
+
+export function collectHardwarePreflight({
+  adb, scrcpy, serial: requestedSerial = '', run = defaultRun,
+  now = () => new Date(), platform = process.platform, arch = process.arch
+}) {
+  const adbVersionResult = run(adb, ['version'], 5_000)
+  const scrcpyVersionResult = run(scrcpy, ['--version'], 5_000)
+  const base = {
+    schemaVersion: 1,
+    createdAt: now().toISOString(),
+    host: { platform, arch },
+    runtime: {
+      adb: redactHardwareOutput(firstLine(adbVersionResult.stdout || adbVersionResult.stderr)),
+      scrcpy: redactHardwareOutput(firstLine(scrcpyVersionResult.stdout || scrcpyVersionResult.stderr))
+    }
+  }
+  if (adbVersionResult.code !== 0 || scrcpyVersionResult.code !== 0 || adbVersionResult.timedOut || scrcpyVersionResult.timedOut) {
+    return {
+      report: blockedReport(base, 'runtime-version-failed', {
+        total: 0, authorized: 0, unauthorized: 0, offline: 0,
+        adb: commandRecord(adbVersionResult, ''), scrcpy: commandRecord(scrcpyVersionResult, '')
+      }),
+      exitCode: 2
+    }
+  }
+  const discoveryResult = run(adb, ['devices', '-l'], 5_000)
+  if (discoveryResult.code !== 0 || discoveryResult.timedOut) {
+    return {
+      report: blockedReport(base, 'adb-discovery-failed', {
+        total: 0, authorized: 0, unauthorized: 0, offline: 0,
+        error: commandRecord(discoveryResult, '')
+      }),
+      exitCode: 2
+    }
+  }
+
+  const devices = parseAdbDevices(discoveryResult.stdout)
+  const authorized = devices.filter((device) => device.state === 'device')
+  const discovery = {
+    total: devices.length,
+    authorized: authorized.length,
+    unauthorized: devices.filter((device) => device.state === 'unauthorized').length,
+    offline: devices.filter((device) => device.state === 'offline').length,
+    noPermissions: devices.filter((device) => device.state === 'no permissions').length
+  }
+  let selected
+  if (requestedSerial) selected = devices.find((device) => device.serial === requestedSerial)
+  else if (authorized.length === 1) selected = authorized[0]
+
+  if (!selected) {
+    const reason = requestedSerial
+      ? 'selected-device-not-found'
+      : authorized.length > 1 ? 'multiple-authorized-devices' : 'no-authorized-device'
+    return { report: blockedReport(base, reason, discovery), exitCode: 2 }
+  }
+  const target = { id: deviceId(selected.serial), connection: connectionKind(selected.serial) }
+  if (selected.state !== 'device') {
+    return { report: blockedReport(base, `device-${selected.state.replace(/\s+/g, '-')}`, discovery, target), exitCode: 2 }
+  }
+
+  const propertyKeys = {
+    androidRelease: 'ro.build.version.release', sdk: 'ro.build.version.sdk', manufacturer: 'ro.product.manufacturer',
+    model: 'ro.product.model', emulator: 'ro.kernel.qemu'
+  }
+  const properties = {}
+  const propertyErrors = {}
+  for (const [name, key] of Object.entries(propertyKeys)) {
+    const result = run(adb, ['-s', selected.serial, 'shell', 'getprop', key], 5_000)
+    if (result.code === 0 && !result.timedOut) properties[name] = redactHardwareOutput(result.stdout, selected.serial)
+    else propertyErrors[name] = commandRecord(result, selected.serial)
+  }
+  Object.assign(target, {
+    physical: properties.emulator !== '1' && target.connection !== 'emulator',
+    androidRelease: properties.androidRelease || 'unknown', sdk: properties.sdk || 'unknown',
+    manufacturer: properties.manufacturer || 'unknown', model: properties.model || 'unknown'
+  })
+  if (propertyErrors.emulator) {
+    return {
+      report: { ...blockedReport(base, 'physical-status-unverified', discovery, target), propertyErrors },
+      exitCode: 2
+    }
+  }
+  if (!target.physical) {
+    return {
+      report: { ...blockedReport(base, 'emulator-not-physical', discovery, target), propertyErrors },
+      exitCode: 2
+    }
+  }
+
+  const probes = {}
+  for (const [name, file, args] of [
+    ['state', adb, ['-s', selected.serial, 'get-state']],
+    ['displaySize', adb, ['-s', selected.serial, 'shell', 'wm', 'size']],
+    ['encoders', scrcpy, [`--serial=${selected.serial}`, '--list-encoders']],
+    ['displays', scrcpy, [`--serial=${selected.serial}`, '--list-displays']],
+    ['cameras', scrcpy, [`--serial=${selected.serial}`, '--list-cameras']],
+    ['cameraSizes', scrcpy, [`--serial=${selected.serial}`, '--list-camera-sizes']]
+  ]) probes[name] = commandRecord(run(file, args), selected.serial)
+
+  const checklist = [
+    ['screen', 'Mirror the physical display and verify input control.'],
+    ['audio', 'Verify forwarded device audio on a supported Android version.'],
+    ['record', 'Create a recording, stop it, and replay the indexed artifact.'],
+    ['camera', 'Run a supported camera source and record the selected camera/size result.'],
+    ['virtual-display', 'Create a virtual display, launch an app, and verify teardown behavior.'],
+    ['control-only', 'Verify keyboard/mouse control with video and audio disabled.'],
+    ['otg', 'Verify no-ADB OTG control with USB debugging not used.'],
+    ['v4l2', 'On Linux with v4l2loopback, verify frames reach the selected sink.'],
+    ['pairing-mdns', 'Pair/connect through Android 11+ wireless debugging and rediscover the device.'],
+    ['multi-device', 'Launch two physical devices and verify independent per-device results.']
+  ].map(([id, instruction]) => ({
+    id,
+    status: id === 'v4l2' && platform !== 'linux' ? 'not-applicable-host' : 'pending-manual-hardware-run',
+    instruction
+  }))
+
+  return {
+    report: { ...base, status: 'ready-for-manual-scenes', discovery, target, propertyErrors, probes, checklist },
+    exitCode: 0
+  }
+}
+
+function parseArgs(argv) {
+  const options = { serial: '', output: '' }
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '--serial' || arg === '--output') {
+      const value = argv[++index]
+      if (!value || value.includes('\0')) throw new Error(`${arg} requires a value.`)
+      options[arg.slice(2)] = value
+    } else if (arg === '--help') options.help = true
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return options
+}
+
+async function resolveBinaries(projectRoot) {
+  const executable = process.platform === 'win32' ? '.exe' : ''
+  const bundle = join(projectRoot, 'vendor', `scrcpy-${process.arch}`)
+  const adb = process.env.SCRCPY_GUI_ADB || join(bundle, `adb${executable}`)
+  const scrcpy = process.env.SCRCPY_GUI_SCRCPY || join(bundle, `scrcpy${executable}`)
+  await Promise.all([access(adb), access(scrcpy)]).catch(() => {
+    throw new Error('Bundled adb/scrcpy are unavailable. Run npm run prepare:scrcpy first or set SCRCPY_GUI_ADB and SCRCPY_GUI_SCRCPY.')
+  })
+  return { adb, scrcpy }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    process.stdout.write('Usage: npm run smoke:hardware -- [--serial SERIAL] [--output REPORT.json]\n')
+    return
+  }
+  const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const binaries = await resolveBinaries(projectRoot)
+  const { report, exitCode } = collectHardwarePreflight({ ...binaries, serial: options.serial })
+  const serialized = `${JSON.stringify(report, null, 2)}\n`
+  if (options.output) {
+    const output = resolve(options.output)
+    if (basename(output).toLowerCase().endsWith('.json') === false) throw new Error('--output must end with .json.')
+    await mkdir(dirname(output), { recursive: true })
+    const handle = await open(output, 'wx', 0o600)
+    try { await handle.writeFile(serialized, 'utf8') } finally { await handle.close() }
+    process.stderr.write(`Hardware preflight ${report.status}; wrote ${output}.\n`)
+  } else process.stdout.write(serialized)
+  process.exitCode = exitCode
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/tests/hardwareSmoke.test.ts
+++ b/tests/hardwareSmoke.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { homedir } from 'node:os'
+// @ts-expect-error The executable .mjs intentionally has no application runtime dependency.
+import { collectHardwarePreflight, parseAdbDevices, redactHardwareOutput } from '../scripts/hardware-smoke.mjs'
+
+type Result = { code: number; stdout: string; stderr: string; timedOut?: boolean }
+type Runner = (file: string, args: string[]) => Result
+
+const ok = (stdout = ''): Result => ({ code: 0, stdout, stderr: '' })
+
+describe('hardware smoke evidence tool', () => {
+  it('parses authorized, unauthorized, offline and permission-denied devices', () => {
+    expect(parseAdbDevices(`List of devices attached
+USB-1 device product:pixel transport_id:1
+10.0.0.2:5555 unauthorized transport_id:2
+USB-3 offline
+USB-4 no permissions (user missing udev rules)
+`)).toEqual([
+      { serial: 'USB-1', state: 'device' },
+      { serial: '10.0.0.2:5555', state: 'unauthorized' },
+      { serial: 'USB-3', state: 'offline' },
+      { serial: 'USB-4', state: 'no permissions' }
+    ])
+  })
+
+  it('writes a structured blocked result when no authorized device exists', () => {
+    const run: Runner = (_file, args) => args[0] === 'devices'
+      ? ok('List of devices attached\nUSB-1 unauthorized\n')
+      : ok(args[0] === '--version' ? 'scrcpy 4.1' : 'Android Debug Bridge version 1.0.41')
+    const result = collectHardwarePreflight({
+      adb: '/adb', scrcpy: '/scrcpy', run, platform: 'linux', arch: 'x64',
+      now: () => new Date('2026-08-15T12:00:00.000Z')
+    })
+    expect(result.exitCode).toBe(2)
+    expect(result.report).toMatchObject({
+      status: 'blocked', reason: 'no-authorized-device',
+      discovery: { total: 1, authorized: 0, unauthorized: 1 }
+    })
+  })
+
+  it('collects bounded probes without retaining serials, addresses or home paths', () => {
+    const serial = '10.0.0.2:5555'
+    const testHome = homedir()
+    const run: Runner = (file, args) => {
+      if (file === '/adb' && args[0] === 'devices') return ok(`List of devices attached\n${serial} device product:pixel\n`)
+      if (args[0] === 'version') return ok('Android Debug Bridge version 1.0.41')
+      if (args[0] === '--version') return ok('scrcpy 4.1 <https://github.com/Genymobile/scrcpy>')
+      if (args.includes('ro.kernel.qemu')) return ok('')
+      if (args.includes('ro.build.version.release')) return ok('16')
+      if (args.includes('ro.build.version.sdk')) return ok('36')
+      if (args.includes('ro.product.manufacturer')) return ok('Acme')
+      if (args.includes('ro.product.model')) return ok('Phone')
+      return ok(`probe for ${serial} at ${testHome}/private and 192.168.1.8:5555`)
+    }
+    const result = collectHardwarePreflight({
+      adb: '/adb', scrcpy: '/scrcpy', serial, run, platform: 'darwin', arch: 'arm64',
+      now: () => new Date('2026-08-15T12:00:00.000Z')
+    })
+    const json = JSON.stringify(result.report)
+    expect(result.exitCode).toBe(0)
+    expect(result.report).toMatchObject({
+      status: 'ready-for-manual-scenes', target: { connection: 'tcpip', physical: true, androidRelease: '16', sdk: '36' }
+    })
+    expect(result.report.target.id).toMatch(/^device-[a-f0-9]{16}$/)
+    expect(result.report.checklist).toHaveLength(10)
+    expect(json).not.toContain(serial)
+    expect(json).not.toContain('192.168.1.8')
+    expect(json).not.toContain(testHome)
+  })
+
+  it('does not accept an emulator as physical-device evidence', () => {
+    const run: Runner = (_file, args) => {
+      if (args[0] === 'devices') return ok('List of devices attached\nemulator-5554 device\n')
+      if (args.includes('ro.kernel.qemu')) return ok('1')
+      return ok(args[0] === '--version' ? 'scrcpy 4.1' : 'Android Debug Bridge version 1.0.41')
+    }
+    const result = collectHardwarePreflight({ adb: '/adb', scrcpy: '/scrcpy', run })
+    expect(result).toMatchObject({ exitCode: 2, report: { status: 'blocked', reason: 'emulator-not-physical' } })
+  })
+
+  it('redacts a selected serial, IP address and home directory', () => {
+    expect(redactHardwareOutput('SERIAL at 10.1.2.3:5555 in /home/user/file', 'SERIAL', '/home/user'))
+      .toBe('[device] at [address] in [home]/file')
+  })
+})


### PR DESCRIPTION
## Purpose
Turn the remaining M0/M3 physical-device gap into an executable evidence workflow without treating capability probes, emulators, or fake ADB output as hardware success.

## Change
- add `npm run smoke:hardware` for one selected authorized physical device
- record host/runtime, hashed target identity, Android metadata, display size, encoders, displays, cameras, and camera sizes
- redact raw serials, IPv4/IPv6 addresses, and home paths; bound every captured output
- reject no-device, ambiguous-device, unauthorized/offline, emulator, runtime-failure, and unverified physical-status states with structured blocked reports
- emit a ten-scene manual hardware checklist without auto-marking any scene passed
- add an exact hardware runbook and connect it to the completion audit

## Validation
- `npm test -- --run` — 20 files / 182 tests
- `npm run typecheck`
- `npm run smoke:hardware -- --help`
- real local no-device preflight returned exit 2 with `blocked / no-authorized-device`, ADB 1.0.41, and scrcpy 4.1
- `git diff --check`

## Boundary
This PR prepares trustworthy evidence collection. It does not satisfy the physical-device exit condition until a device is actually connected and every required scene is recorded.