### PR TITLE
security: add CodeQL and release provenance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '23 4 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   package:
@@ -68,10 +68,29 @@ jobs:
   publish:
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
+      - name: Export SPDX SBOM
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p artifacts/SBOM
+          curl --fail --location --silent --show-error \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'X-GitHub-Api-Version: 2026-03-10' \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/dependency-graph/sbom" \
+            | jq '.sbom' > "artifacts/SBOM/Scrcpy.GUI-$version.sbom.spdx.json"
+          jq --exit-status '.spdxVersion == "SPDX-2.3" and (.packages | length > 0)' \
+            "artifacts/SBOM/Scrcpy.GUI-$version.sbom.spdx.json" > /dev/null
       - name: Generate SHA-256 manifest
         shell: bash
         run: |
@@ -80,6 +99,12 @@ jobs:
             | xargs -0 sha256sum \
             | awk '{ name=$2; sub(/^.*\//, "", name); print $1 "  " name }' \
             | sort -k2 > SHA256SUMS.txt
+      - name: Attest release assets
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            artifacts/**/*
+            SHA256SUMS.txt
       - uses: softprops/action-gh-release@v3
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Security
+
+- Add private vulnerability-reporting guidance and weekly/push/PR CodeQL analysis for JavaScript and TypeScript.
+- Reduce default Release workflow permissions, export a checksummed SPDX 2.3 SBOM, and generate GitHub/Sigstore build-provenance attestations for every release asset.
+
 ## 2.4.0
 
 This is the first stable release of the rebuilt Scrcpy GUI. It completes the M0–M4 software roadmap with the scrcpy 4.1 scene model, device workspace, local diagnostics, device groups, and bounded multi-device automation. See the release smoke report for the hardware, signing, and installer verification gaps that remain explicit rather than inferred.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Download the package for your platform from [GitHub Releases](https://github.com
 
 The current stable artifacts are not code-signed or notarized. Your operating system may ask you to confirm that you trust the downloaded application. Verify the download against the release `SHA256SUMS.txt` before opening it.
 
+Releases from v2.4.1 also include an SPDX SBOM and GitHub build-provenance attestations. After downloading an asset, verify its workflow identity with `gh attestation verify PATH/TO/ASSET -R SimonAKing/scrcpy-gui` in addition to checking the SHA-256 manifest.
+
 The exact automated checks and unverified hardware/installer matrix are recorded in the [v2.4.0 release smoke report](docs/RELEASE_SMOKE_V2.4.0.md).
 
 ### Use another scrcpy installation
@@ -198,6 +200,7 @@ The proposed product direction, functional requirements, architecture, security 
 ## Community and credits
 
 - Questions, bugs, and feature requests: [GitHub Issues](https://github.com/SimonAKing/scrcpy-gui/issues)
+- Security vulnerabilities: follow the private process in [SECURITY.md](SECURITY.md), not a public issue
 - The Russian translation was originally contributed by [@dEN5-tech](https://github.com/dEN5-tech) in [#69](https://github.com/SimonAKing/scrcpy-gui/pull/69) and migrated to the 2.0 interface.
 - Thanks to [Genymobile/scrcpy](https://github.com/Genymobile/scrcpy) and every Scrcpy GUI contributor.
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -74,6 +74,8 @@ scrcpy 是 Genymobile 维护的高性能轻量工具。它可以通过 USB 或 T
 
 当前正式版构建尚未进行代码签名或公证，操作系统可能会要求你确认信任该应用。打开前请使用 Release 中的 `SHA256SUMS.txt` 校验下载文件。
 
+从 v2.4.1 起，Release 还会附带 SPDX SBOM 和 GitHub 构建来源证明。下载资产后，除核对 SHA-256 清单外，还可运行 `gh attestation verify PATH/TO/ASSET -R SimonAKing/scrcpy-gui` 验证其工作流来源。
+
 本次实际执行的自动检查，以及尚未验证的硬件/安装矩阵，记录在 [v2.4.0 Release smoke 报告](docs/RELEASE_SMOKE_V2.4.0.md)中。
 
 ### 使用其他 scrcpy 安装
@@ -198,6 +200,7 @@ npm run build:dir
 ## 社区与致谢
 
 - 问题、Bug 与功能建议：[GitHub Issues](https://github.com/SimonAKing/scrcpy-gui/issues)
+- 安全漏洞：请按 [SECURITY.md](SECURITY.md) 私下报告，不要提交公开 issue
 - 俄语翻译最初由 [@dEN5-tech](https://github.com/dEN5-tech) 在 [#69](https://github.com/SimonAKing/scrcpy-gui/pull/69) 中贡献，并已迁移到 2.0 界面。
 - 感谢 [Genymobile/scrcpy](https://github.com/Genymobile/scrcpy) 以及 Scrcpy GUI 的所有贡献者。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,26 @@
 
 ## Supported versions
 
-Security fixes are provided for the latest 2.x release. The legacy 1.x Electron application is no longer supported.
+Security fixes are provided for the latest stable `2.4.x` release line. Older beta and `1.x` releases are no longer supported; reproduce a report on the latest stable release when practical.
 
-## Reporting a vulnerability
+## Private reporting
 
-Please do not open a public issue for a suspected vulnerability. Use GitHub's private vulnerability reporting flow on the repository Security tab, or email the maintainer address listed in `package.json`.
+Do not open a public issue for a suspected vulnerability. Use [GitHub private vulnerability reporting](https://github.com/SimonAKing/scrcpy-gui/security/advisories/new), or email the maintainer address listed in `package.json`, so the maintainer can investigate before details or exploit steps are public.
 
-Include the affected version, operating system, reproduction steps, and expected impact. Reports are normally acknowledged within seven days.
+Include:
+
+- the affected Scrcpy GUI, operating-system, scrcpy, ADB, and Android versions;
+- the security boundary involved, such as IPC, command construction, local files, diagnostics/redaction, updates, or release integrity;
+- minimal reproduction steps and the expected versus observed result;
+- impact and prerequisites, including whether user interaction or an already-authorized device is required;
+- a redacted diagnostic bundle when it is relevant.
+
+Never submit real pairing codes, API keys, access tokens, raw device serials, private addresses, or unnecessary local paths. Review every attachment even when Scrcpy GUI generated it with default redaction.
+
+The maintainer aims to acknowledge a complete report within seven days and provide an initial assessment or request for evidence within fourteen days. Resolution and disclosure timing depend on severity, reproducibility, upstream coordination, and release readiness.
+
+## Coordinated disclosure
+
+Please allow a reasonable remediation window before public disclosure. Confirmed vulnerabilities will be handled through a GitHub Security Advisory where appropriate, with affected versions, mitigations, credit preferences, and the fixed release recorded before the advisory is published.
+
+Security reports about scrcpy itself should be reported to [Genymobile/scrcpy](https://github.com/Genymobile/scrcpy/security); reports about Electron, Chromium, Android platform tools, or another dependency should also be coordinated with the relevant upstream project. Scrcpy GUI will still assess whether bundling, configuration, or application behavior requires a local mitigation.

--- a/docs/RELEASE_SMOKE_V2.4.0.md
+++ b/docs/RELEASE_SMOKE_V2.4.0.md
@@ -48,3 +48,5 @@ Every current asset was matched to its published `SHA256SUMS.txt` entry before i
 - Chocolatey Community moderation/availability until the external repository accepts the package.
 
 These gaps are release-note disclosures, not claims that the features fail. They are also not converted into support claims from fake-binary, parser, or CI packaging evidence.
+
+Supply-chain note: v2.4.0 predates repository CodeQL, Release SBOM, and GitHub artifact-attestation enforcement. Those gates apply prospectively beginning with v2.4.1; this record does not retrofit provenance onto previously built assets.


### PR DESCRIPTION
## Confirmed gaps
- npm audit and open Dependabot alerts: 0 vulnerabilities
- Code scanning: no analysis existed
- Secret scanning and push protection were disabled
- private vulnerability reporting was disabled
- Release jobs used global `contents: write` and emitted neither SBOM nor provenance

## Change
- add weekly/push/PR CodeQL v4 with `security-extended` JavaScript/TypeScript queries
- expand the existing SECURITY.md while preserving its email reporting path
- enable GitHub private vulnerability reporting, Secret Scanning, and Push Protection in repository settings
- reduce default Release permission to `contents: read`; grant publish-only contents/id-token/attestations writes
- export the repository Dependency Graph as a checksummed SPDX 2.3 release SBOM
- attest every package, the SBOM, and SHA256SUMS.txt with `actions/attest@v4`
- document `gh attestation verify` in English and Chinese

## Validation
- `npm audit --json`: 0 vulnerabilities across 475 dependency entries
- GitHub Dependabot open alerts: 0
- live SBOM export: SPDX 2.3, 463 packages
- private vulnerability reporting now enabled
- Secret Scanning and Push Protection now enabled
- all workflow YAML parsed
- actionlint passed for CodeQL and Release workflows
- `git diff --check`

## Prospective boundary
The attestation/SBOM release gates begin with v2.4.1. They do not retrofit provenance onto already-built v2.4.0 assets.