### PR TITLE
security: remediate CodeQL file handling alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add private vulnerability-reporting guidance and weekly/push/PR CodeQL analysis for JavaScript and TypeScript.
 - Reduce default Release workflow permissions, export a checksummed SPDX 2.3 SBOM, and generate GitHub/Sigstore build-provenance attestations for every release asset.
+- Close file path-replacement races by validating and reading configuration, artifact indexes, and imported documents through one bounded descriptor, and stream checksum-verified scrcpy archives directly into the extractor without writing network bytes to a temporary archive.
 
 ## 2.4.0
 

--- a/scripts/fetch-scrcpy.mjs
+++ b/scripts/fetch-scrcpy.mjs
@@ -48,11 +48,12 @@ for (const artifact of selected) {
   if (actualHash !== artifact.sha256) throw new Error(`Checksum mismatch for ${artifact.file}.`)
 
   const temporary = await mkdtemp(join(tmpdir(), 'scrcpy-gui-bundle-'))
-  const archivePath = join(temporary, artifact.file)
   const extracted = join(temporary, 'extracted')
   await mkdir(extracted)
-  await writeFile(archivePath, archive)
-  const result = spawnSync('tar', ['-xf', archivePath, '-C', extracted, '--strip-components=1'], { stdio: 'inherit' })
+  const result = spawnSync('tar', ['-xf', '-', '-C', extracted, '--strip-components=1'], {
+    input: archive,
+    stdio: ['pipe', 'inherit', 'inherit']
+  })
   if (result.status !== 0) throw new Error(`Could not extract ${artifact.file}.`)
 
   await writeFile(join(extracted, '.scrcpy-bundle'), `${VERSION} ${artifact.sha256}\n`)

--- a/src/main/artifactService.ts
+++ b/src/main/artifactService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir, open, readFile, rename, rm, stat, unlink } from 'node:fs/promises'
+import { mkdir, open, rename, rm, stat, unlink } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join } from 'node:path'
 import type {
   ArtifactKind,
@@ -12,6 +12,7 @@ import type {
   ApkInstallResult,
   ScrcpySession
 } from '../shared/types'
+import { readBoundedRegularUtf8File } from './safeFile'
 
 interface ArtifactIndex {
   schemaVersion: 1
@@ -224,9 +225,11 @@ export class ArtifactService {
     await mkdir(this.directory, { recursive: true })
     let contents: string
     try {
-      const info = await stat(this.indexPath)
-      if (!info.isFile() || info.size > MAX_INDEX_BYTES) return
-      contents = await readFile(this.indexPath, 'utf8')
+      contents = await readBoundedRegularUtf8File(
+        this.indexPath,
+        MAX_INDEX_BYTES,
+        'Artifact index must be a regular file no larger than 4 MiB.'
+      )
     } catch {
       return
     }

--- a/src/main/configRepository.ts
+++ b/src/main/configRepository.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { constants } from 'node:fs'
-import { access, copyFile, mkdir, open, readFile, rename, rm, stat } from 'node:fs/promises'
+import { access, copyFile, mkdir, open, rename, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   AppConfigV3,
@@ -22,6 +22,7 @@ import { configView, defaultPersistedConfig, legacyConfigView } from '../shared/
 import { automationMacro, boundedString, launchConfig, runtimeConfig, strictBoolean } from './ipcValidation'
 import { validateDeviceAddress } from './scrcpy'
 import { failureFromUnknown, operationFailure } from '../shared/errors'
+import { readBoundedRegularUtf8File } from './safeFile'
 
 const MAX_CONFIG_BYTES = 2 * 1024 * 1024
 const MAX_COLLECTION_SIZE = 1_000
@@ -452,9 +453,11 @@ export class ConfigRepository {
   private async readValidated(path: string): Promise<AppConfigV3 | undefined> {
     let contents: string
     try {
-      const info = await stat(path)
-      if (!info.isFile() || info.size > MAX_CONFIG_BYTES) return undefined
-      contents = await readFile(path, 'utf8')
+      contents = await readBoundedRegularUtf8File(
+        path,
+        MAX_CONFIG_BYTES,
+        'Configuration must be a regular file no larger than 2 MiB.'
+      )
     } catch {
       return undefined
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, clipboard, dialog, globalShortcut, ipcMain, Menu, n
 import { basename, extname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { randomUUID } from 'node:crypto'
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
 import { arch, homedir, platform, release } from 'node:os'
 import type {
   BatchPreflightRequest,
@@ -68,6 +68,7 @@ import { deviceCapabilityService } from './deviceCapabilityService'
 import { AutomationRunner } from './automationRunner'
 import { BatchAutomationService, type PreparedBatchResource } from './batchAutomationService'
 import { automationTransferService } from './automationTransferService'
+import { readBoundedRegularUtf8File } from './safeFile'
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
@@ -659,8 +660,11 @@ handle('profile:import-preview', async (_event, runtime: RuntimeConfig) => {
     if (selection.canceled || !selection.filePaths[0]) {
       return operationFailure('PROFILE_IMPORT_CANCELED', 'profile-import-preview', 'Profile import canceled.')
     }
-    const info = await stat(selection.filePaths[0])
-    if (!info.isFile() || info.size > 2 * 1024 * 1024) throw new TypeError('Profile file must be a regular file no larger than 2 MiB.')
+    const contents = await readBoundedRegularUtf8File(
+      selection.filePaths[0],
+      2 * 1024 * 1024,
+      'Profile file must be a regular file no larger than 2 MiB.'
+    )
     const snapshot = configRepository?.snapshot()
     if (!snapshot) throw new Error('Configuration repository is not ready.')
     const environment = await getEnvironment(runtimeConfig(runtime))
@@ -668,7 +672,7 @@ handle('profile:import-preview', async (_event, runtime: RuntimeConfig) => {
     return {
       ok: true,
       data: profileTransferService.preview(
-        await readFile(selection.filePaths[0], 'utf8'), snapshot.profiles, snapshot.locale, selectedVersion
+        contents, snapshot.profiles, snapshot.locale, selectedVersion
       )
     }
   } catch (error) {
@@ -724,9 +728,12 @@ handle('automation:import-preview', async () => {
     if (selection.canceled || !selection.filePaths[0]) {
       return operationFailure('AUTOMATION_IMPORT_CANCELED', 'automation-import-preview', 'Automation import canceled.')
     }
-    const info = await stat(selection.filePaths[0])
-    if (!info.isFile() || info.size > 2 * 1024 * 1024) throw new TypeError('Automation file must be a regular file no larger than 2 MiB.')
-    return { ok: true, data: automationTransferService.preview(await readFile(selection.filePaths[0], 'utf8')) }
+    const contents = await readBoundedRegularUtf8File(
+      selection.filePaths[0],
+      2 * 1024 * 1024,
+      'Automation file must be a regular file no larger than 2 MiB.'
+    )
+    return { ok: true, data: automationTransferService.preview(contents) }
   } catch (error) {
     return failureFromUnknown(error, 'AUTOMATION_IMPORT_PREVIEW_FAILED', 'automation-import-preview', 'Unable to preview the automation import.')
   }

--- a/src/main/safeFile.ts
+++ b/src/main/safeFile.ts
@@ -1,0 +1,33 @@
+import { constants } from 'node:fs'
+import { open } from 'node:fs/promises'
+
+const READ_CHUNK_BYTES = 64 * 1024
+
+export async function readBoundedRegularUtf8File(
+  path: string,
+  maxBytes: number,
+  invalidMessage: string
+): Promise<string> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) throw new TypeError('File size limit must be a positive integer.')
+
+  const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW || 0))
+  try {
+    const info = await handle.stat()
+    if (!info.isFile() || info.size > maxBytes) throw new TypeError(invalidMessage)
+
+    const chunks: Buffer[] = []
+    let totalBytes = 0
+    while (totalBytes <= maxBytes) {
+      const remaining = maxBytes + 1 - totalBytes
+      const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining))
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, null)
+      if (bytesRead === 0) break
+      chunks.push(chunk.subarray(0, bytesRead))
+      totalBytes += bytesRead
+    }
+    if (totalBytes > maxBytes) throw new TypeError(invalidMessage)
+    return Buffer.concat(chunks, totalBytes).toString('utf8')
+  } finally {
+    await handle.close()
+  }
+}

--- a/tests/safeFile.test.ts
+++ b/tests/safeFile.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { readBoundedRegularUtf8File } from '../src/main/safeFile'
+
+const directories: string[] = []
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'scrcpy-gui-safe-file-'))
+  directories.push(directory)
+  return directory
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('readBoundedRegularUtf8File', () => {
+  it('reads a regular file through the descriptor that was validated', async () => {
+    const directory = await temporaryDirectory()
+    const path = join(directory, 'config.json')
+    await writeFile(path, '{"safe":true}\n', 'utf8')
+
+    await expect(readBoundedRegularUtf8File(path, 64, 'invalid file')).resolves.toBe('{"safe":true}\n')
+  })
+
+  it('rejects directories and files over the byte limit', async () => {
+    const directory = await temporaryDirectory()
+    const nested = join(directory, 'nested')
+    const oversized = join(directory, 'oversized.json')
+    await mkdir(nested)
+    await writeFile(oversized, '12345', 'utf8')
+
+    await expect(readBoundedRegularUtf8File(nested, 4, 'invalid file')).rejects.toThrow('invalid file')
+    await expect(readBoundedRegularUtf8File(oversized, 4, 'invalid file')).rejects.toThrow('invalid file')
+  })
+
+  it.runIf(process.platform !== 'win32')('does not follow a symbolic link', async () => {
+    const directory = await temporaryDirectory()
+    const target = join(directory, 'target.json')
+    const link = join(directory, 'link.json')
+    await writeFile(target, '{"secret":true}', 'utf8')
+    await symlink(target, link)
+
+    await expect(readBoundedRegularUtf8File(link, 64, 'invalid file')).rejects.toMatchObject({ code: 'ELOOP' })
+  })
+})


### PR DESCRIPTION
## Summary

- validate and read configuration, artifact-index, profile, and automation files through one bounded file descriptor
- reject symbolic links where the platform supports `O_NOFOLLOW` and detect files that grow beyond the configured limit while being read
- pass checksum-verified scrcpy archives directly to `tar` over stdin instead of writing network bytes to a temporary archive
- add focused regression coverage and document the security change

Closes the root causes reported by CodeQL alerts #1, #2, #3, #4, and #5. The alerts themselves should close automatically after the fixed revision is analyzed on `master`.

## Verification

- `npm test` (21 files, 185 tests)
- `npm run build`
- streamed tar extraction smoke test using a real gzip archive
- `git diff --check`