### PR TITLE
release: prepare GPL v2.4.1 security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.4.1
+
+This GPL-3.0-only patch release ships the security and release-provenance improvements completed after v2.4.0. The planned MIT change is not included and remains pending explicit consent for the migrated #69 Russian translation.
+
 ### Security
 
 - Add private vulnerability-reporting guidance and weekly/push/PR CodeQL analysis for JavaScript and TypeScript.

--- a/docs/RELEASE_SMOKE_V2.4.1.md
+++ b/docs/RELEASE_SMOKE_V2.4.1.md
@@ -1,0 +1,36 @@
+# v2.4.1 Release verification
+
+v2.4.1 is a GPL-3.0-only security and release-provenance patch over v2.4.0. It deliberately does not apply the pending MIT change or claim new physical-device coverage.
+
+## Verified before tagging
+
+- `package.json`, `package-lock.json`, and the Chocolatey manifest all declare version `2.4.1`;
+- `package.json` and the project `LICENSE` remain GPL-3.0-only;
+- `npm test`: 21 test files / 185 tests;
+- `npm run build`, including the Node and Renderer type checks;
+- `npm run icons:check`: 11 generated icon assets;
+- pull-request validation on macOS, Ubuntu, and Windows;
+- pull-request CodeQL analysis and the latest `master` analysis report no open alerts;
+- no physical Android device was attached to the release host.
+
+## Tag workflow gates
+
+The tag workflow must independently:
+
+1. run the full tests and build each configured macOS, Windows, and Linux package;
+2. download only the checksum-pinned official scrcpy 4.1 bundles;
+3. extract the current-architecture archive on each runner and execute packaged scrcpy 4.1 and ADB 1.0.41;
+4. build the Chocolatey package with the final Windows installer SHA-256;
+5. export a non-empty SPDX 2.3 SBOM from GitHub's dependency graph;
+6. include every package and the SBOM in `SHA256SUMS.txt`;
+7. generate GitHub/Sigstore build-provenance attestations before publishing the assets.
+
+The release must stay unpublished if any required packaging, smoke, checksum, SBOM, or attestation step fails. Chocolatey Community publication remains an optional final job until `CHOCO_API_KEY` is configured.
+
+## Explicitly unverified
+
+- physical Android screen, audio, recording, pairing, multi-device, Camera, Virtual display, V4L2, Control-only, and OTG paths;
+- manual interactive installer wording and retained-preference review on each host OS;
+- Apple signing/notarization, Windows publisher reputation, and Chocolatey Community moderation.
+
+These are disclosed evidence gaps, not inferred feature failures or successes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-gui",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vue": "^3.5.41"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A modern, secure desktop GUI for scrcpy",
   "author": "Simon Ma <simon@tomotoes.com>",
   "homepage": "https://github.com/SimonAKing/scrcpy-gui",

--- a/packaging/chocolatey/scrcpy-gui.nuspec
+++ b/packaging/chocolatey/scrcpy-gui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scrcpy-gui</id>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <title>Scrcpy GUI</title>
     <authors>Simon Ma and contributors</authors>
     <owners>SimonAKing</owners>


### PR DESCRIPTION
## Summary

- release the merged CodeQL remediation and release-provenance work as v2.4.1
- keep the project and Russian localization under GPL-3.0-only in this release
- leave the separate MIT Draft blocked on #69 contributor consent and move it to v2.4.2 after this release
- align npm/lockfile/Chocolatey versions and record truthful pre-tag evidence

## Verification

- `npm test` — 21 files / 185 tests
- `npm run build`
- `npm run icons:check` — 11 assets
- package/lock/Chocolatey version consistency check
- GPL-3.0-only metadata and license-text check
- Chocolatey nuspec XML validation

## Release gate

After this PR passes macOS, Ubuntu, Windows, and CodeQL, merge it and tag the exact merge commit as `v2.4.1`. The tag workflow must pass packaging, packaged-runtime smoke, SBOM, checksum, and artifact-attestation steps before the GitHub release is considered complete.