### PR TITLE
fix: select gzip mode for streamed tar bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 This GPL-3.0-only patch release ships the security and release-provenance improvements completed after v2.4.0. The planned MIT change is not included and remains pending explicit consent for the migrated #69 Russian translation.
 
+### Fixed
+
+- Explicitly select gzip decompression when streaming `.tar.gz` scrcpy bundles into GNU tar, while retaining ZIP extraction for Windows bundles.
+
 ### Security
 
 - Add private vulnerability-reporting guidance and weekly/push/PR CodeQL analysis for JavaScript and TypeScript.

--- a/scripts/fetch-scrcpy.mjs
+++ b/scripts/fetch-scrcpy.mjs
@@ -50,7 +50,8 @@ for (const artifact of selected) {
   const temporary = await mkdtemp(join(tmpdir(), 'scrcpy-gui-bundle-'))
   const extracted = join(temporary, 'extracted')
   await mkdir(extracted)
-  const result = spawnSync('tar', ['-xf', '-', '-C', extracted, '--strip-components=1'], {
+  const extractionMode = artifact.file.endsWith('.tar.gz') ? '-xzf' : '-xf'
+  const result = spawnSync('tar', [extractionMode, '-', '-C', extracted, '--strip-components=1'], {
     input: archive,
     stdio: ['pipe', 'inherit', 'inherit']
   })


### PR DESCRIPTION
## Root cause

The first v2.4.1 tag run failed only on Ubuntu. The GNU tar log states `Archive is compressed. Use -z option`: unlike BSD tar on macOS, GNU tar does not auto-detect gzip when the verified archive is supplied through stdin (`-f -`).

## Fix

- use `-xzf -` for the predefined `.tar.gz` scrcpy artifacts
- retain `-xf -` for Windows ZIP artifacts
- keep the checksum-before-extraction and no-network-bytes-to-file security properties

## Verification

- exact gzip stdin extraction smoke with a real `.tar.gz`
- `npm test` — 21 files / 185 tests
- `npm run typecheck`
- the rerun release workflow will be the Linux integration proof

After merge, the unpublished `v2.4.1` tag will be recreated at the fixed, fully validated merge commit. No GitHub Release or assets were created by the failed run.