### PR TITLE
fix: extract verified Windows bundles in memory

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,12 @@ jobs:
       - if: runner.os == 'Linux'
         run: npm run icons:check
       - run: npm run build
+      - name: Prepare official Windows runtime bundle
+        if: runner.os == 'Windows'
+        run: npm run prepare:scrcpy -- win32
+      - name: Smoke prepared Windows runtime bundle
+        if: runner.os == 'Windows'
+        run: npm run smoke:prepared-runtime
       - name: Validate Chocolatey metadata
         if: runner.os == 'Windows'
         run: choco pack packaging/chocolatey/scrcpy-gui.nuspec --version 0.0.0-ci --outputdirectory release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This GPL-3.0-only patch release ships the security and release-provenance improv
 
 ### Fixed
 
-- Explicitly select gzip decompression when streaming `.tar.gz` scrcpy bundles into GNU tar, while retaining ZIP extraction for Windows bundles.
+- Use explicit gzip streaming for `.tar.gz` bundles and bounded in-memory .NET ZIP extraction on Windows, avoiding platform-specific stdin behavior while keeping verified network archives off disk.
 
 ### Security
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "icons:check": "node scripts/generate-icons.mjs --check",
     "prepare:scrcpy": "node scripts/fetch-scrcpy.mjs",
     "smoke:packaged-runtime": "node scripts/smoke-packaged-runtime.mjs",
+    "smoke:prepared-runtime": "node scripts/smoke-prepared-runtime.mjs",
     "smoke:hardware": "node scripts/hardware-smoke.mjs",
     "build:dir": "npm run build && npm run prepare:scrcpy && electron-builder --dir",
     "dist": "npm run build && npm run prepare:scrcpy && electron-builder --publish never",

--- a/scripts/extract-verified-zip.ps1
+++ b/scripts/extract-verified-zip.ps1
@@ -1,0 +1,80 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Destination,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ExpectedRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName System.IO.Compression
+
+$destinationRoot = [System.IO.Path]::GetFullPath($Destination)
+$trimCharacters = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+$destinationPrefix = $destinationRoot.TrimEnd($trimCharacters) + [System.IO.Path]::DirectorySeparatorChar
+[System.IO.Directory]::CreateDirectory($destinationRoot) | Out-Null
+
+$archiveBytes = [System.IO.MemoryStream]::new()
+$archive = $null
+try {
+  [Console]::OpenStandardInput().CopyTo($archiveBytes)
+  if ($archiveBytes.Length -eq 0 -or $archiveBytes.Length -gt 128MB) {
+    throw 'Verified ZIP input must be between 1 byte and 128 MiB.'
+  }
+  $archiveBytes.Position = 0
+  $archive = [System.IO.Compression.ZipArchive]::new(
+    $archiveBytes,
+    [System.IO.Compression.ZipArchiveMode]::Read,
+    $false
+  )
+
+  $prefix = "$ExpectedRoot/"
+  $fileCount = 0
+  $totalBytes = [long]0
+  foreach ($entry in $archive.Entries) {
+    if ($entry.FullName -eq $prefix) { continue }
+    if (-not $entry.FullName.StartsWith($prefix, [System.StringComparison]::Ordinal)) {
+      throw "ZIP entry is outside the expected root: $($entry.FullName)"
+    }
+
+    $relative = $entry.FullName.Substring($prefix.Length)
+    if ([string]::IsNullOrEmpty($relative)) { continue }
+    if ($relative.Contains('\') -or $relative.Contains(':') -or $relative -match '(^|/)\.\.?(/|$)') {
+      throw "ZIP entry has an unsafe path: $($entry.FullName)"
+    }
+
+    $target = [System.IO.Path]::GetFullPath(
+      [System.IO.Path]::Combine($destinationRoot, $relative.Replace('/', [System.IO.Path]::DirectorySeparatorChar))
+    )
+    if (-not $target.StartsWith($destinationPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+      throw "ZIP entry escapes the destination: $($entry.FullName)"
+    }
+
+    if ($entry.FullName.EndsWith('/')) {
+      [System.IO.Directory]::CreateDirectory($target) | Out-Null
+      continue
+    }
+
+    $fileCount += 1
+    $totalBytes += $entry.Length
+    if ($fileCount -gt 1000 -or $totalBytes -gt 512MB) {
+      throw 'ZIP contents exceed the extraction limits.'
+    }
+
+    [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($target)) | Out-Null
+    $entryStream = $entry.Open()
+    $output = [System.IO.File]::Open($target, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    try {
+      $entryStream.CopyTo($output)
+    } finally {
+      $output.Dispose()
+      $entryStream.Dispose()
+    }
+  }
+
+  if ($fileCount -eq 0) { throw 'Verified ZIP contained no files.' }
+} finally {
+  if ($null -ne $archive) { $archive.Dispose() }
+  $archiveBytes.Dispose()
+}

--- a/scripts/fetch-scrcpy.mjs
+++ b/scripts/fetch-scrcpy.mjs
@@ -50,11 +50,17 @@ for (const artifact of selected) {
   const temporary = await mkdtemp(join(tmpdir(), 'scrcpy-gui-bundle-'))
   const extracted = join(temporary, 'extracted')
   await mkdir(extracted)
-  const extractionMode = artifact.file.endsWith('.tar.gz') ? '-xzf' : '-xf'
-  const result = spawnSync('tar', [extractionMode, '-', '-C', extracted, '--strip-components=1'], {
-    input: archive,
-    stdio: ['pipe', 'inherit', 'inherit']
-  })
+  const result = process.platform === 'win32' && artifact.file.endsWith('.zip')
+    ? spawnSync('powershell.exe', [
+        '-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+        '-File', join(projectRoot, 'scripts', 'extract-verified-zip.ps1'),
+        '-Destination', extracted,
+        '-ExpectedRoot', artifact.file.slice(0, -'.zip'.length)
+      ], { input: archive, stdio: ['pipe', 'inherit', 'inherit'], windowsHide: true })
+    : spawnSync('tar', [artifact.file.endsWith('.tar.gz') ? '-xzf' : '-xf', '-', '-C', extracted, '--strip-components=1'], {
+        input: archive,
+        stdio: ['pipe', 'inherit', 'inherit']
+      })
   if (result.status !== 0) throw new Error(`Could not extract ${artifact.file}.`)
 
   await writeFile(join(extracted, '.scrcpy-bundle'), `${VERSION} ${artifact.sha256}\n`)

--- a/scripts/smoke-prepared-runtime.mjs
+++ b/scripts/smoke-prepared-runtime.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from 'node:child_process'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const executable = process.platform === 'win32' ? 'scrcpy.exe' : 'scrcpy'
+const adbExecutable = process.platform === 'win32' ? 'adb.exe' : 'adb'
+const runtimeDirectory = join(projectRoot, 'vendor', `scrcpy-${process.arch}`)
+
+function run(name, args, expected) {
+  const path = join(runtimeDirectory, name)
+  const result = spawnSync(path, args, { encoding: 'utf8', windowsHide: true })
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim()
+  if (result.error || result.status !== 0 || !expected.test(output)) {
+    throw new Error(`Prepared runtime smoke failed for ${name} (${result.status ?? 'spawn error'}).\n${output}\n${result.error || ''}`)
+  }
+  console.log(output.split(/\r?\n/)[0])
+}
+
+run(executable, ['--version'], /^scrcpy\s+4\.1\b/im)
+run(adbExecutable, ['version'], /^Android Debug Bridge version\s+1\.0\.41\b/im)
+console.log(`Verified prepared runtime in vendor/scrcpy-${process.arch}.`)


### PR DESCRIPTION
## Confirmed root cause

The Windows release smoke failure reproduced twice on the same `windows-2025-vs2026` runner image and the same checksum-pinned scrcpy 4.1 ZIP. v2.4.0 succeeded when tar read that ZIP from a file; both runs after switching tar to stdin produced `0xC0000135` from the packaged `scrcpy.exe`. Linux independently showed that stdin archive handling differs by tar implementation.

## Fix

- keep checksum verification before any extraction
- use bounded .NET `ZipArchive` extraction from standard input on Windows, without writing the network archive to disk
- enforce one expected archive root, path containment, no traversal/ADS paths, at most 1,000 files, 128 MiB input, and 512 MiB expanded data
- retain explicit gzip streaming for `.tar.gz` artifacts
- add a permanent Windows PR gate that prepares the official pinned bundle and directly executes scrcpy 4.1 and ADB 1.0.41 before Chocolatey validation

## Local verification

- prepared macOS runtime smoke passed
- Node syntax checks passed
- workflow YAML parsed
- exact gzip stdin extraction was already proven with a real archive in #202

The Windows CI job in this PR is the authoritative PowerShell/ZIP/runtime integration proof.