### PR TITLE
docs: record v2.4.1 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The current stable artifacts are not code-signed or notarized. Your operating sy
 
 Releases from v2.4.1 also include an SPDX SBOM and GitHub build-provenance attestations. After downloading an asset, verify its workflow identity with `gh attestation verify PATH/TO/ASSET -R SimonAKing/scrcpy-gui` in addition to checking the SHA-256 manifest.
 
-The exact automated checks and unverified hardware/installer matrix are recorded in the [v2.4.0 release smoke report](docs/RELEASE_SMOKE_V2.4.0.md).
+The exact automated checks, SBOM/provenance evidence, and unverified hardware matrix are recorded in the [v2.4.1 release smoke report](docs/RELEASE_SMOKE_V2.4.1.md). The earlier three-platform install/upgrade/uninstall evidence remains in the [v2.4.0 report](docs/RELEASE_SMOKE_V2.4.0.md).
 
 ### Use another scrcpy installation
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -76,7 +76,7 @@ scrcpy 是 Genymobile 维护的高性能轻量工具。它可以通过 USB 或 T
 
 从 v2.4.1 起，Release 还会附带 SPDX SBOM 和 GitHub 构建来源证明。下载资产后，除核对 SHA-256 清单外，还可运行 `gh attestation verify PATH/TO/ASSET -R SimonAKing/scrcpy-gui` 验证其工作流来源。
 
-本次实际执行的自动检查，以及尚未验证的硬件/安装矩阵，记录在 [v2.4.0 Release smoke 报告](docs/RELEASE_SMOKE_V2.4.0.md)中。
+本次实际执行的自动检查、SBOM/来源证明和尚未验证的硬件矩阵，记录在 [v2.4.1 Release smoke 报告](docs/RELEASE_SMOKE_V2.4.1.md)中。此前三平台安装、升级和卸载证据仍保留在 [v2.4.0 报告](docs/RELEASE_SMOKE_V2.4.0.md)中。
 
 ### 使用其他 scrcpy 安装
 

--- a/docs/M0_M4_COMPLETION_AUDIT.md
+++ b/docs/M0_M4_COMPLETION_AUDIT.md
@@ -1,6 +1,6 @@
 # M0–M4 completion audit
 
-Audit baseline: `master` after PR #196, 2026-08-15. This document treats missing direct evidence as incomplete; parser tests and CI are not substituted for physical-device results.
+Audit baseline: `master` after PR #203, 2026-08-16. This document treats missing direct evidence as incomplete; parser tests and CI are not substituted for physical-device results.
 
 ## Status vocabulary
 
@@ -12,14 +12,14 @@ Audit baseline: `master` after PR #196, 2026-08-15. This document treats missing
 
 | Requirement | Status | Authoritative evidence |
 | --- | --- | --- |
-| Unit/integration/typecheck/build on three hosts | Complete | Validate jobs on PR #196; 19 files / 177 tests after tagged migration coverage in #194 |
-| Official scrcpy download and SHA-256 | Complete | pinned scrcpy 4.1 hashes in `scripts/fetch-scrcpy.mjs`; [v2.4.0 release workflow](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31890315296) |
-| Stable, complete asset names | Complete | v2.4.0 has 15 assets across macOS, Windows, Linux, Chocolatey package, and manifest |
+| Unit/integration/typecheck/build on three hosts | Complete | [PR #203 validation](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31937865855); 21 files / 185 tests, build, prepared Windows runtime, and Chocolatey metadata |
+| Official scrcpy download and SHA-256 | Complete | pinned scrcpy 4.1 hashes in `scripts/fetch-scrcpy.mjs`; [v2.4.1 release workflow](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31940894381) |
+| Stable, complete asset names | Complete | v2.4.1 has 16 assets: 14 platform/Chocolatey packages, SPDX SBOM, and manifest |
 | Execute packaged scrcpy/ADB | Complete | release jobs execute scrcpy 4.1 and ADB 1.0.41 from extracted final archives |
 | Installed GUI starts on three hosts | Complete | [published-asset lifecycle/startup run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892938302) loads the production `file://` Renderer on macOS, Windows, and Ubuntu/Xvfb |
 | Install, upgrade, uninstall | Complete for hosted native paths | the same run performs beta.6 → v2.4.0 lifecycle through DMG, NSIS, and Debian packages; interactive UX remains a disclosed manual gap |
-| Asset manifest | Complete | all 14 package entries matched `SHA256SUMS.txt` and uploaded digests |
-| Issue reply with release and verification | Complete where the request is fulfilled | #139 has a v2.4.0 reply but remains open because Community publication has not occurred |
+| Asset manifest and provenance | Complete | all 15 non-manifest assets match `SHA256SUMS.txt` and uploaded digests; strict SLSA verification covers all 16 assets |
+| Issue reply with release and verification | Complete where the request is fulfilled | #139 remains open because Community publication has not occurred; verified `.nupkg` files are attached to stable releases |
 
 ## M0 — stable baseline
 
@@ -29,7 +29,7 @@ Audit baseline: `master` after PR #196, 2026-08-15. This document treats missing
 - packaged-runtime smoke and installed-GUI lifecycle/startup smoke;
 - trusted IPC sender, payload, navigation, CSP, and contract coverage;
 - fake process launch/startup/exit/fatal/duplicate-session integration tests;
-- bug template, diagnostics, changelog, release notes, and stable v2.4.0 publication;
+- bug template, diagnostics, changelog, release notes, and stable v2.4.0 plus v2.4.1 publication;
 - explicit migration cases for the real persisted shapes in v2.0.0-beta.1, beta.2, and beta.3;
 - no open P0 issue; the only open issue is the Chocolatey enhancement #139.
 

--- a/docs/RELEASE_SMOKE_V2.4.1.md
+++ b/docs/RELEASE_SMOKE_V2.4.1.md
@@ -27,6 +27,24 @@ The tag workflow must independently:
 
 The release must stay unpublished if any required packaging, smoke, checksum, SBOM, or attestation step fails. Chocolatey Community publication remains an optional final job until `CHOCO_API_KEY` is configured.
 
+## Published result
+
+The final [`v2.4.1` Release workflow](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31940894381) passed every required job from the tag that peels to commit `8487b019e7bda281e0c2da1324ed8386eec51ce6`:
+
+- macOS, Windows, and Linux each completed tests, packaging, final-archive extraction, and packaged scrcpy 4.1 / ADB 1.0.41 execution;
+- Windows also built `scrcpy-gui.2.4.1.nupkg` with the final x64 installer checksum;
+- the published stable [v2.4.1 release](https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.1) contains 16 assets: 14 platform/Chocolatey packages, one SPDX SBOM, and `SHA256SUMS.txt`;
+- all 15 non-manifest assets are present in `SHA256SUMS.txt`, and every listed digest matches GitHub's uploaded-asset digest;
+- the SPDX 2.3 SBOM contains 466 packages;
+- strict `gh attestation verify` checks for the Chocolatey package, SBOM, and checksum manifest passed with the repository, `release.yml`, tag ref, source commit, and GitHub-hosted runner identity pinned;
+- the single SLSA provenance statement covers all 16 published assets and identifies `release.yml@refs/tags/v2.4.1` as its builder.
+
+The optional Chocolatey Community job completed safely without a push because `CHOCO_API_KEY` is not configured. The verified `.nupkg` is attached to the GitHub release, while issue #139 remains open for real Community submission, moderation, and install/upgrade evidence.
+
+## Pre-publication correction
+
+The first tag attempt failed before creating any GitHub Release or assets: GNU tar required explicit gzip mode for streamed `.tar.gz` input, and Windows tar stdin extraction produced a runtime that failed DLL loading. PRs #202 and #203 fixed those platform-specific extraction paths, added a permanent Windows prepared-runtime gate, and passed three-platform validation plus CodeQL. The unpublished tag was then recreated on the verified fix commit before the successful workflow above. The original source state remains recoverable at commit `e372f45f559b5be6598700fc0a059267f0178375`.
+
 ## Explicitly unverified
 
 - physical Android screen, audio, recording, pairing, multi-device, Camera, Virtual display, V4L2, Control-only, and OTG paths;


### PR DESCRIPTION
## Summary

- record the successful final v2.4.1 three-platform workflow and the pre-publication correction trail
- document 16 release assets, 15 matching checksum entries, the 466-package SPDX 2.3 SBOM, and strict SLSA verification
- preserve the explicit hardware, signing, interactive installer, and Chocolatey Community gaps
- point both READMEs to the current release evidence while retaining v2.4.0 installer lifecycle evidence
- refresh the M0–M4 completion audit baseline without converting missing hardware evidence into a pass

## Verification

- final Release workflow: https://github.com/SimonAKing/scrcpy-gui/actions/runs/31940894381
- stable release: https://github.com/SimonAKing/scrcpy-gui/releases/tag/v2.4.1
- all manifest entries matched GitHub asset digests
- strict attestation checks pinned repository, workflow, tag, commit, and hosted runner identity
- `git diff --check`

Documentation-only; no runtime or generated asset changed.