### PR TITLE
docs: record v2.4.1 installer lifecycle

### DIFF
--- a/docs/M0_M4_COMPLETION_AUDIT.md
+++ b/docs/M0_M4_COMPLETION_AUDIT.md
@@ -16,8 +16,8 @@ Audit baseline: `master` after PR #203, 2026-08-16. This document treats missing
 | Official scrcpy download and SHA-256 | Complete | pinned scrcpy 4.1 hashes in `scripts/fetch-scrcpy.mjs`; [v2.4.1 release workflow](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31940894381) |
 | Stable, complete asset names | Complete | v2.4.1 has 16 assets: 14 platform/Chocolatey packages, SPDX SBOM, and manifest |
 | Execute packaged scrcpy/ADB | Complete | release jobs execute scrcpy 4.1 and ADB 1.0.41 from extracted final archives |
-| Installed GUI starts on three hosts | Complete | [published-asset lifecycle/startup run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31892938302) loads the production `file://` Renderer on macOS, Windows, and Ubuntu/Xvfb |
-| Install, upgrade, uninstall | Complete for hosted native paths | the same run performs beta.6 → v2.4.0 lifecycle through DMG, NSIS, and Debian packages; interactive UX remains a disclosed manual gap |
+| Installed GUI starts on three hosts | Complete | [v2.4.0 → v2.4.1 published-asset lifecycle run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31942357974) loads the production `file://` Renderer on macOS, Windows, and Ubuntu/Xvfb |
+| Install, upgrade, uninstall | Complete for hosted native paths | the same run verifies the v2.4.1 manifest and performs stable-to-patch lifecycle through DMG, NSIS, and Debian packages; interactive UX remains a disclosed manual gap |
 | Asset manifest and provenance | Complete | all 15 non-manifest assets match `SHA256SUMS.txt` and uploaded digests; strict SLSA verification covers all 16 assets |
 | Issue reply with release and verification | Complete where the request is fulfilled | #139 remains open because Community publication has not occurred; verified `.nupkg` files are attached to stable releases |
 

--- a/docs/RELEASE_SMOKE_V2.4.1.md
+++ b/docs/RELEASE_SMOKE_V2.4.1.md
@@ -41,6 +41,16 @@ The final [`v2.4.1` Release workflow](https://github.com/SimonAKing/scrcpy-gui/a
 
 The optional Chocolatey Community job completed safely without a push because `CHOCO_API_KEY` is not configured. The verified `.nupkg` is attached to the GitHub release, while issue #139 remains open for real Community submission, moderation, and install/upgrade evidence.
 
+## Published installer lifecycle result
+
+The post-release [`v2.4.0` → `v2.4.1` installer lifecycle run](https://github.com/SimonAKing/scrcpy-gui/actions/runs/31942357974) passed against the published assets:
+
+- macOS (17s): selected the runner-architecture DMG, installed v2.4.0 into `/Applications`, replaced it with v2.4.1, checked the bundle/runtime versions and production `file://` Renderer startup, then removed the app;
+- Ubuntu (45s): verified and installed the v2.4.0 Debian package, upgraded to v2.4.1, checked dpkg/runtime versions and Renderer startup under Xvfb, then removed the package;
+- Windows (2m16s): silently installed the v2.4.0 x64 NSIS package, upgraded to v2.4.1, checked registry/runtime versions and production Renderer startup, then ran the registered uninstaller and confirmed removal.
+
+Every v2.4.1 installer was matched to its published `SHA256SUMS.txt` entry before installation. This is hosted-runner native install/upgrade/startup/uninstall evidence; it does not replace manual interactive UX, signing reputation, preference-retention, or physical-device verification.
+
 ## Pre-publication correction
 
 The first tag attempt failed before creating any GitHub Release or assets: GNU tar required explicit gzip mode for streamed `.tar.gz` input, and Windows tar stdin extraction produced a runtime that failed DLL loading. PRs #202 and #203 fixed those platform-specific extraction paths, added a permanent Windows prepared-runtime gate, and passed three-platform validation plus CodeQL. The unpublished tag was then recreated on the verified fix commit before the successful workflow above. The original source state remains recoverable at commit `e372f45f559b5be6598700fc0a059267f0178375`.


### PR DESCRIPTION
## Summary

- record the successful published v2.4.0 → v2.4.1 native lifecycle run
- document checksum verification, installation, stable-to-patch upgrade, installed Renderer/runtime startup, and removal on macOS, Ubuntu, and Windows
- update the M0–M4 audit to point to current stable release evidence
- retain manual UX, signing, preference, Chocolatey Community, and physical-device gaps

## Evidence

- workflow: https://github.com/SimonAKing/scrcpy-gui/actions/runs/31942357974
- macOS: 17s
- Ubuntu: 45s
- Windows: 2m16s
- `git diff --check`

Documentation-only.