### PR TITLE
ci: default lifecycle smoke to v2.4.1

### DIFF
--- a/.github/workflows/installer-lifecycle.yml
+++ b/.github/workflows/installer-lifecycle.yml
@@ -6,11 +6,11 @@ on:
       previous_version:
         description: Previously published version to install first
         required: true
-        default: 2.0.0-beta.6
+        default: 2.4.0
       current_version:
         description: Published version to upgrade to and uninstall
         required: true
-        default: 2.4.0
+        default: 2.4.1
 
 permissions:
   contents: read

--- a/docs/INSTALLER_LIFECYCLE_SMOKE.md
+++ b/docs/INSTALLER_LIFECYCLE_SMOKE.md
@@ -1,6 +1,6 @@
 # Published installer lifecycle smoke
 
-The `Installer lifecycle smoke` workflow validates real GitHub Release assets rather than build-directory approximations. A maintainer supplies an already published previous version and current version; the default path is `v2.0.0-beta.6` → `v2.4.0`.
+The `Installer lifecycle smoke` workflow validates real GitHub Release assets rather than build-directory approximations. A maintainer supplies an already published previous version and current version; the default path is the latest verified stable upgrade, currently `v2.4.0` → `v2.4.1`.
 
 ## Covered paths
 


### PR DESCRIPTION
## Summary

- update manual lifecycle defaults from the old beta.6 → v2.4.0 path to the latest verified stable upgrade, v2.4.0 → v2.4.1
- keep inputs overridable for any published version pair
- align the operator documentation with the workflow

## Evidence

The new default pair already passed all three native lifecycle jobs: https://github.com/SimonAKing/scrcpy-gui/actions/runs/31942357974

- macOS DMG: pass
- Windows NSIS: pass
- Ubuntu Debian: pass
- workflow YAML parse: pass
- `git diff --check`: pass