### PR TITLE
fix: publish MIT v2.4.3 on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,26 @@
 
 ## Unreleased
 
+## 2.4.3
+
+- Accept both LF and Windows CRLF line endings when verifying the packaged MIT license.
+- Report project and upstream license verification failures separately.
+- Supersede the unpublished `v2.4.2` tag, whose release workflow correctly stopped before publication when the Windows-only line-ending check failed.
+
 ## 2.4.2
 
 This licensing and verification-tooling patch release applies the MIT License prospectively to Scrcpy GUI while preserving the separate licenses and notices of the bundled official scrcpy runtime. Releases through v2.4.1 remain under GPL-3.0-only.
 
 ### Changed
 
-- Replace the project license with the OSI-approved MIT text after auditing contribution provenance and obtaining the required contributor consent.
+- Replace the project license with the OSI-approved MIT text after completing the current-tree contribution audit and maintainer ownership attestation.
 - Package the Scrcpy GUI license and third-party notice as visible resources, and fail packaged-runtime smoke checks when either the GUI MIT text or bundled scrcpy Apache-2.0 text is missing.
 - Remove an unused legacy tray icon that was the only remaining current-tree artifact from an otherwise removed external contribution.
 - Add published installer lifecycle/startup verification, tagged beta migration fixtures, and a redacted physical-device preflight/runbook without claiming missing hardware results.
 
 ## 2.4.1
 
-This GPL-3.0-only patch release ships the security and release-provenance improvements completed after v2.4.0. The planned MIT change is not included and remains pending explicit consent for the migrated #69 Russian translation.
+This GPL-3.0-only patch release ships the security and release-provenance improvements completed after v2.4.0. The planned MIT change is not included and remained pending completion of the current-tree contribution audit.
 
 ### Fixed
 

--- a/docs/RELEASE_SMOKE_V2.4.3.md
+++ b/docs/RELEASE_SMOKE_V2.4.3.md
@@ -1,0 +1,23 @@
+# v2.4.3 Release verification
+
+v2.4.3 is the publishable MIT licensing patch. It supersedes the unpublished `v2.4.2` tag without moving or rewriting that public tag.
+
+## v2.4.2 failure record
+
+The v2.4.2 release workflow passed macOS and Linux packaging but stopped before publication in the Windows packaged-runtime smoke. Git for Windows checked out the MIT license with CRLF line endings, while the smoke accepted only an LF header. The package still contained the MIT text; the verifier rejected the valid Windows representation.
+
+v2.4.3 accepts `MIT License` followed by either LF or CRLF and reports project-license and upstream-license failures independently.
+
+## Required before tagging
+
+- completed current-tree relicensing audit recorded in `RELICENSING_V2.4.2.md`;
+- `npm test`;
+- `npm run typecheck`;
+- `npm run build`;
+- macOS, Windows, and Linux pull-request checks;
+- CodeQL analysis with no open alert on the release revision;
+- final archives contain `LICENSE.scrcpy-gui.txt`, `THIRD_PARTY_NOTICES.md`, and the platform-specific upstream scrcpy license file;
+- packaged `scrcpy --version` and `adb version` checks remain successful;
+- the Release workflow publishes a checksummed SPDX 2.3 SBOM and GitHub/Sigstore attestations for all release assets.
+
+The physical-device, signing/notarization, manual installer, and Chocolatey Community gaps disclosed for v2.4.1 remain unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-gui",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.5.41"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-gui",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A modern, secure desktop GUI for scrcpy",
   "author": "Simon Ma <simon@tomotoes.com>",
   "homepage": "https://github.com/SimonAKing/scrcpy-gui",

--- a/packaging/chocolatey/scrcpy-gui.nuspec
+++ b/packaging/chocolatey/scrcpy-gui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scrcpy-gui</id>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <title>Scrcpy GUI</title>
     <authors>Simon Ma and contributors</authors>
     <owners>SimonAKing</owners>

--- a/scripts/smoke-packaged-runtime.mjs
+++ b/scripts/smoke-packaged-runtime.mjs
@@ -55,8 +55,11 @@ try {
     readFile(runtimeLicense, 'utf8'),
     readFile(guiLicense, 'utf8')
   ])
-  if (!/Apache License\s+Version 2\.0/s.test(runtimeLicenseText) || !guiLicenseText.startsWith('MIT License\n')) {
-    throw new Error('The packaged archive does not preserve the expected scrcpy Apache-2.0 and Scrcpy GUI MIT license texts.')
+  if (!/Apache License\s+Version 2\.0/s.test(runtimeLicenseText)) {
+    throw new Error('The packaged archive does not preserve the expected scrcpy Apache-2.0 license text.')
+  }
+  if (!/^MIT License\r?\n/.test(guiLicenseText)) {
+    throw new Error('The packaged archive does not preserve the expected Scrcpy GUI MIT license text.')
   }
   run(scrcpy, ['--version'], /^scrcpy\s+4\.1\b/im)
   run(adb, ['version'], /^Android Debug Bridge version\s+1\.0\.41\b/im)


### PR DESCRIPTION
## Summary
- accept both LF and Windows CRLF in the packaged MIT license smoke
- report project and upstream license failures separately
- publish this correction as v2.4.3 without moving the failed v2.4.2 tag

## Root cause
The v2.4.2 Windows release package contained the MIT license, but Git for Windows preserved it with CRLF and the verifier required an LF-only header. The workflow correctly stopped before creating a GitHub Release.

## Validation
- MIT header predicate accepts LF and CRLF and rejects a missing newline
- `npm test`: 21 files / 185 tests
- `npm run typecheck`
- `npm run build`
- `npm run icons:check`: 11 assets

Closes the release-only verification failure in run 31944834267.