### PR TITLE
fix: synchronize refreshed wireless devices with tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Clear the background-recording flags forced by the Record-only scene when returning to Screen, Camera, or Virtual display playback.
+- Synchronize manual ADB device refreshes with the tracker snapshot so newly connected wireless devices are immediately available to device actions.
 
 ## 2.4.3
 

--- a/src/main/deviceTracker.ts
+++ b/src/main/deviceTracker.ts
@@ -130,6 +130,11 @@ export class DeviceTracker {
     return this.devices.map((device) => ({ ...device }))
   }
 
+  synchronize(devices: Device[]): Device[] {
+    this.apply(devices, this.source, 'ADB device snapshot refreshed.')
+    return this.snapshot()
+  }
+
   private launchTrack(): void {
     if (this.stopped) return
     const generation = ++this.generation

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -153,7 +153,7 @@ function executeBinary(file: string, args: string[], timeout = 20_000): Promise<
 export async function listDevices(runtime: RuntimeConfig): Promise<OperationResult<Device[]>> {
   try {
     const result = await adbCommand(runtime, ['devices', '-l'])
-    return { ok: true, data: parseAdbDevices(result.stdout) }
+    return { ok: true, data: deviceTracker.synchronize(parseAdbDevices(result.stdout)) }
   } catch (error) {
     return failureFromUnknown(error, 'ADB_LIST_FAILED', 'device-list', 'Unable to list Android devices.', {
       retryable: true,

--- a/tests/deviceTracker.test.ts
+++ b/tests/deviceTracker.test.ts
@@ -54,6 +54,21 @@ describe('parseTrackDevicesSnapshot', () => {
 })
 
 describe('DeviceTracker', () => {
+  it('synchronizes a polled snapshot before the streaming tracker starts', () => {
+    const child = new FakeChild()
+    const tracker = new DeviceTracker({ spawnProcess: (() => child as unknown as ChildProcessWithoutNullStreams) })
+    trackers.push(tracker)
+    const events: DeviceTrackerEvent[] = []
+    tracker.subscribe((event) => events.push(event))
+
+    const devices = parseTrackDevicesSnapshot('WIFI:5555\tdevice model:Wireless_Phone transport_id:3\n')
+    expect(tracker.synchronize(devices)).toMatchObject([
+      { serial: 'WIFI:5555', state: 'device', connection: 'wireless' }
+    ])
+    expect(tracker.start('/fake/adb')).toMatchObject([{ serial: 'WIFI:5555' }])
+    expect(events[0]).toMatchObject({ status: 'tracking', source: 'track', revision: 1 })
+  })
+
   it('emits added, changed and removed deltas without duplicate serials', () => {
     const child = new FakeChild()
     const tracker = new DeviceTracker({ spawnProcess: (() => child as unknown as ChildProcessWithoutNullStreams) })


### PR DESCRIPTION
## Summary

- synchronize successful `adb devices -l` refreshes into the main-process tracker snapshot
- eliminate the startup race where the renderer saw a wireless device before availability-gated device actions did
- cover the pre-stream synchronization behavior with a tracker regression test

## Diagnosis

The diagnostic bundle in #209 shows the wireless device was online and later tracked successfully. The `Device is no longer available` event occurred before `adb track-devices -l` delivered its first snapshot, while the renderer had already populated the same device from `adb devices -l`. This keeps both views consistent immediately and does not depend on ADB mDNS support.

The separate Record-only state leak from the same report was fixed by #210. Thanks again to @QiuYuCode for the detailed diagnostic bundle and for separating the two symptoms.

## Testing

- `npm test -- --run tests/deviceTracker.test.ts` — 8 tests passed

Closes #209